### PR TITLE
这次改了英文文本了

### DIFF
--- a/Content/Items/Weapons/CrystalBalls/NightProjection.cs
+++ b/Content/Items/Weapons/CrystalBalls/NightProjection.cs
@@ -12,7 +12,7 @@ namespace CalamityEntropy.Content.Items.Weapons.CrystalBalls
         {
             Item.width = 44;
             Item.height = 44;
-            Item.damage = 109;
+            Item.damage = 115;
             Item.noMelee = true;
             Item.noUseGraphic = true;
             Item.useAnimation = Item.useTime = 20;
@@ -25,7 +25,7 @@ namespace CalamityEntropy.Content.Items.Weapons.CrystalBalls
             Item.rare = ItemRarityID.Cyan;
             Item.shoot = ModContent.ProjectileType<NightProjectionHoldout>();
             Item.shootSpeed = 16f;
-            Item.mana = 6;
+            Item.mana = 3;
             Item.DamageType = DamageClass.Magic;
         }
         public override bool MagicPrefix()

--- a/Content/Items/Weapons/CrystalBalls/OverloadLunar.cs
+++ b/Content/Items/Weapons/CrystalBalls/OverloadLunar.cs
@@ -26,7 +26,7 @@ namespace CalamityEntropy.Content.Items.Weapons.CrystalBalls
             Item.rare = ItemRarityID.Red;
             Item.shoot = ModContent.ProjectileType<OverloadLunarHoldout>();
             Item.shootSpeed = 16f;
-            Item.mana = 14;
+            Item.mana = 6;
             Item.DamageType = DamageClass.Magic;
         }
         public override void AddRecipes()

--- a/Content/Items/Weapons/RuneSong.cs
+++ b/Content/Items/Weapons/RuneSong.cs
@@ -9,7 +9,7 @@ namespace CalamityEntropy.Content.Items.Weapons
     {
         public override void SetDefaults()
         {
-            Item.damage = 950;
+            Item.damage = 75;
             Item.DamageType = DamageClass.Melee;
             Item.width = 56;
             Item.noUseGraphic = true;

--- a/Localization/en-US_Mods.CalamityEntropy.hjson
+++ b/Localization/en-US_Mods.CalamityEntropy.hjson
@@ -1595,18 +1595,17 @@ Items: {
 MariviniumSet:
 	'''
 	Armor Bonus:
-	-30% Melee Damage Taken
 	+10 Minion Slot
 	+100% Summon Damage
 	+40% Whip Range
 	+5% Summon Crit
-	+15% Damage Reduce
+	+5% Damage Reduce
 	+100 Armor Penetration
 	if your crit chance is over 100%, convert excess crit chance into damage bonus
 	+140 Rogue Stealth
 	When standing, increase life regen
 	Immunity to most debuffs
-	When using true melee weapons, +15% Damage reduce and 25 defense
+	When using true melee weapons, +10% Damage reduce and 25 defense
 	Stealth strike has a probability of causing an water explosion
 	Obtain 2 layers of shields, which will take 10 seconds to recover after being shattered
 	After shield shattered, treat 140 health points and increace your damage by 100% for 5 seconds
@@ -2283,8 +2282,6 @@ Configs: {
 vfb:
 	'''
 	Armor Bonus:
-	+15% Damage
-	+10% Crit
 	+20 Armor Penetration
 	Hitting the target will increase void energy
 	Provides movement and flight speed bonuses based on the amount of void energy
@@ -2298,21 +2295,21 @@ helmvfc:
 	'''
 helmvfd:
 	'''
-	+30% Attack Speed
-	+10% Damage Reduce
+	+24% Attack Speed
+	+5% Damage Reduce
 	Accumulates more void energy when hitting targets.
 	'''
 helmvfs: Projectile damage increases with time
 helmvfl:
 	'''
 	+15% movement speed
-	+150 Max Stealth
+	+135 Max Stealth
 	Stealth strikes will accumulate more void energy
 	'''
 helmvfe:
 	'''
-	+8 Max Minions
-	+95% Summon Damage
+	+7 Max Minions
+	+80% Summon Damage
 	Summon a Void Symbiont fight for you
 	'''
 Reforge: Reforge

--- a/Localization/en-US_Mods.CalamityEntropy.hjson
+++ b/Localization/en-US_Mods.CalamityEntropy.hjson
@@ -795,7 +795,11 @@ Items: {
 
 	Barren: {
 		DisplayName: 『Barren』
-		Tooltip: Rogue Projectile obtain micro tracking
+		Tooltip: 
+			'''
+			Rogue Projectile obtain micro tracking
+			But decrease 15% rogueDC damage and 15% rogueDC critchance
+			'''
 	}
 
 	Confuse: {
@@ -854,12 +858,13 @@ Items: {
 		Tooltip:
 			'''
 			Rogue Projectile obtain micro tracking
+			Decrease 15% rogueDC damage and 15% rogueDC critchance
 			Attack to exert deceive debuff in enemies that Reduce their movement speed
 			Launch shadow flames during attack
 			+3% damage for each summon slots
 			+32% Damage
 			+4 Void Touch
-			+24% Damage taken
+			+30% Damage taken
 			-70% Life Regen
 			+16% Mana Cost
 			-4% Crit

--- a/Localization/en-US_Mods.CalamityEntropy.hjson
+++ b/Localization/en-US_Mods.CalamityEntropy.hjson
@@ -307,7 +307,7 @@ Items: {
 	}
 
 	TemperanceCard: {
-		Tooltip: +2 Minion Slot
+		Tooltip: +1 Minion Slot
 		DisplayName: 『Temperance』
 	}
 
@@ -319,21 +319,22 @@ Items: {
 	OracleDeck: {
 		Tooltip:
 			'''
-			+8% Crit Chance
-			+30% Move Speed
-			+12 Max Stealth
+			+10% Crit Chance
+			+15% Move Speed
+			+8 Max Stealth
 			-30% Mana Cost
-			-12% Damage Taken
+			-10% Damage Taken
 			+10 Armor Penetration
-			+2 Minion Slot
+			+1 Minion Slot
+			+5% Melee Attack Speed
 			+100% Light
-			Heal players nearby 20 per 5 sec
+			Heal players nearby 10 per 5 sec
 			'''
 		DisplayName: Oracle Deck
 	}
 
 	MetropolisCard: {
-		Tooltip: +10 Max Stealth
+		Tooltip: +5 Max Stealth
 		DisplayName: 『Metropolis』
 	}
 
@@ -348,7 +349,7 @@ Items: {
 	}
 
 	EnduranceCard: {
-		Tooltip: -12% Damage Taken
+		Tooltip: -5% Damage Taken
 		DisplayName: 『Endurance』
 	}
 
@@ -440,7 +441,7 @@ Items: {
 			Puts a shell around the owner when below 50% life that reduces damage taken
 			Absorbs 25% of damage done to players on your team when above 25% life
 			Provide you with a Holy Shield that can withstand damage once
-			This effect has a 90 second cooldown time
+			This effect has a 120 second cooldown time
 			'''
 	}
 
@@ -463,7 +464,7 @@ Items: {
 		DisplayName: Holy Moonlight
 		Tooltip:
 			'''
-			Get a magic shield every thirty seconds, which is equivalent to 60% of the magic limit,
+			Get a magic shield every thirty seconds, which is equivalent to 50% of the magic limit,
 			During the existence of the Magic Shield, increase movement speed by 10% and reduce magic consumption by 10%,
 			The shield will deal damage to the enemies it touches,
 			When the magic shield is broken, it eliminates its own magic sickness and benefits, and returns to its full magic value,
@@ -495,7 +496,7 @@ Items: {
 		Tooltip:
 			'''
 			+10% Damage
-			+10% Crit Chance
+			+8% Crit Chance
 			+20% Movement Speed
 			'''
 		DisplayName: Void Faquir Cuises
@@ -514,8 +515,8 @@ Items: {
 	VoidFaquirDevourerHelm: {
 		Tooltip:
 			'''
-			+30% Melee Damage
-			+25% Melee Crit Chance
+			+20% Melee Damage
+			+15% Melee Crit Chance
 			'''
 		DisplayName: Void Faquir Devourer Helm
 	}
@@ -523,7 +524,7 @@ Items: {
 	VoidFaquirCosmosHood: {
 		Tooltip:
 			'''
-			+35% Magic Damage
+			+30% Magic Damage
 			+25% Magic Crit Chance
 			+150 Max Mana
 			'''
@@ -548,8 +549,8 @@ Items: {
 		DisplayName: Void Faquir Shadow Helm
 		Tooltip:
 			'''
-			+35% Ranged Damage
-			+35% Ranged Crit Chance
+			+32% Ranged Damage
+			+30% Ranged Crit Chance
 			'''
 	}
 

--- a/Localization/en-US_Mods.CalamityEntropy.hjson
+++ b/Localization/en-US_Mods.CalamityEntropy.hjson
@@ -953,7 +953,7 @@ Items: {
 			'''
 			Charging when using weapons,
 			when it is fully charged, release the mouse button to release a black laser ring
-			deals 225 damage every 3 frames
+			deals 75 damage every 3 frames
 			"Consume thy enemy!"
 			'''
 		DisplayName: Maw Of The Void
@@ -1050,9 +1050,9 @@ Items: {
 	NihilityShell: {
 		Tooltip:
 			'''
-			Critical hits will deal 250% damage
+			Critical hits will deal 210% damage
 			Probability of obtaining an energy shell during critical strike
-			The energy shell can reduce the damage you receive by 40% once
+			The energy shell can reduce the damage you receive by 15% once
 			You can only get a maximum of two shells
 			'''
 		DisplayName: Nihility Shell
@@ -1211,7 +1211,6 @@ Items: {
 		DisplayName: Marivinium Body Armor
 		Tooltip:
 			'''
-			+15% Damage Reduce
 			+15% Damage
 			+15 Crit Chance
 			+250 Max Mana
@@ -1601,7 +1600,6 @@ MariviniumSet:
 	Armor Bonus:
 	+10 Minion Slot
 	+100% Summon Damage
-	+40% Whip Range
 	+5% Summon Crit
 	+5% Damage Reduce
 	+100 Armor Penetration

--- a/Localization/en-US_Mods.CalamityEntropy.hjson
+++ b/Localization/en-US_Mods.CalamityEntropy.hjson
@@ -615,6 +615,7 @@ Items: {
 			+ 8 Life Regen/s
 			-8% Crit Chance
 			Remove defense damage.
+			''NO ONE loves defense damage''
 			-Death Mode-
 			'''
 	}
@@ -628,7 +629,7 @@ Items: {
 		Tooltip:
 			'''
 			Gives you 30% extra mana
-			Every 1 extra mana provides 0.3% magic damage bonus
+			Every 1 extra mana provides 0.1% magic damage bonus
 			'''
 		DisplayName: Archmage's Handmirror
 	}
@@ -643,11 +644,8 @@ Items: {
 			'''
 			+15% damage
 			+2HP/s Life Regen
-			+4 Max Minions
-			+75% Minions Knockback
-			+5% Crit Chance
-			+5% Move Speed
-			+5% Melee Speed
+			+2 Max Minions
+			Greatly increase your various attributes
 			'''
 		DisplayName: Celestial Ring
 	}
@@ -749,7 +747,7 @@ Items: {
 		Tooltip:
 			'''
 			Provide you with a Holy Shield that can withstand damage once
-			This effect has a 90 second cooldown time
+			This effect has a 120 second cooldown time
 			Loot from hallow monsters
 			'''
 		DisplayName: Holy Mantle


### PR DESCRIPTION
本次修改包括：
1.英文翻译同步
2.降低了水晶球的耗魔
3.符文之歌面板降低到75（大约是花后泰拉刃的水平）

关于先知的改动建议：
1.普通模式基础伤害提升至80
2.普通模式基础血量提升至54000(大死灾影和花的战斗都总共需要造成超过20w伤害)

魂幡的面板降低至现在的80%左右