### PR TITLE
一些新改动的平衡性提交

### DIFF
--- a/Content/Buffs/VoidTouch.cs
+++ b/Content/Buffs/VoidTouch.cs
@@ -36,7 +36,7 @@ namespace CalamityEntropy.Content.Buffs
             Dust.NewDust(player.Center, player.width, player.height, DustID.CorruptSpray, (float)r.NextDouble() * 6 - 3, (float)r.NextDouble() * 6 - 3);
             if (!player.GetModPlayer<EPlayerDash>().velt)
             {
-                player.velocity *= 0.99f;
+                player.velocity *= 0.95f;
             }
             for (int i = 0; i < 1; i++)
             {

--- a/Content/Items/Ammo/CondensedBullet.cs
+++ b/Content/Items/Ammo/CondensedBullet.cs
@@ -16,7 +16,7 @@ namespace CalamityEntropy.Content.Items.Ammo
 
         public override void SetDefaults()
         {
-            Item.damage = 3;
+            Item.damage = 1;
             Item.DamageType = DamageClass.Ranged;
             Item.width = 8;
             Item.height = 8;

--- a/Content/Items/Ammo/HiveArrow.cs
+++ b/Content/Items/Ammo/HiveArrow.cs
@@ -16,7 +16,7 @@ namespace CalamityEntropy.Content.Items.Ammo
         {
             Item.width = 14;
             Item.height = 36;
-            Item.damage = 8;
+            Item.damage = 4;
             Item.DamageType = DamageClass.Ranged;
             Item.rare = ItemRarityID.Orange;
             Item.maxStack = Item.CommonMaxStack;

--- a/Content/Items/Ammo/HiveBullet.cs
+++ b/Content/Items/Ammo/HiveBullet.cs
@@ -15,7 +15,7 @@ namespace CalamityEntropy.Content.Items.Ammo
 
         public override void SetDefaults()
         {
-            Item.damage = 8;
+            Item.damage = 2;
             Item.DamageType = DamageClass.Ranged;
             Item.width = 8;
             Item.height = 8;

--- a/Content/Items/ProphetBag.cs
+++ b/Content/Items/ProphetBag.cs
@@ -57,7 +57,7 @@ namespace CalamityEntropy.Content.Items
             itemLoot.Add(ModContent.ItemType<SpiritBanner>(), new Fraction(4, 5));
             itemLoot.Add(ModContent.ItemType<RuneMachineGun>(), new Fraction(4, 5));
             itemLoot.Add(ModContent.ItemType<ProphecyFlyingKnife>(), new Fraction(4, 5));
-            itemLoot.Add(ModContent.ItemType<ForeseeOrb>(), new Fraction(4, 5));
+            itemLoot.Add(ModContent.ItemType<ForeseeOrb>(), new Fraction(1, 5));
             itemLoot.Add(ModContent.ItemType<RuneWing>(), new Fraction(4, 5));
             itemLoot.Add(ModContent.ItemType<BookMarkForesee>(), new Fraction(2, 5));
         }

--- a/Content/Items/Weapons/Fractal/ShatteredFractal.cs
+++ b/Content/Items/Weapons/Fractal/ShatteredFractal.cs
@@ -24,7 +24,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Fractal
     {
         public override void SetDefaults()
         {
-            Item.damage = 66;
+            Item.damage = 40;
             Item.crit = 3;
             Item.DamageType = ModContent.GetInstance<TrueMeleeDamageClass>();
             Item.width = 48;

--- a/Content/Items/Weapons/Revelation.cs
+++ b/Content/Items/Weapons/Revelation.cs
@@ -17,10 +17,10 @@ namespace CalamityEntropy.Content.Items.Weapons
         {
             Item.width = 36;
             Item.height = 34;
-            Item.damage = 116;
+            Item.damage = 115;
             Item.noMelee = true;
             Item.noUseGraphic = true;
-            Item.useAnimation = Item.useTime = 16;
+            Item.useAnimation = Item.useTime = 20;
             Item.useStyle = ItemUseStyleID.Swing;
             Item.knockBack = 1f;
             Item.UseSound = SoundID.Item1;

--- a/Content/Items/Weapons/TheBeginingAndTheEnd.cs
+++ b/Content/Items/Weapons/TheBeginingAndTheEnd.cs
@@ -22,13 +22,11 @@ namespace CalamityEntropy.Content.Items.Weapons
         {
             Item.width = 50;
             Item.height = 38;
-            Item.damage = 2200;
-            Item.ArmorPenetration = 80;
+            Item.damage = 3000;
             Item.noMelee = true;
             Item.noUseGraphic = true;
-            Item.useAnimation = Item.useTime = 20;
+            Item.useAnimation = Item.useTime = 15;
             Item.useStyle = ItemUseStyleID.Swing;
-            Item.ArmorPenetration = 86;
             Item.knockBack = 1f;
             Item.UseSound = null;
             Item.autoReuse = true;

--- a/Content/Items/Weapons/TheBeginingAndTheEnd.cs
+++ b/Content/Items/Weapons/TheBeginingAndTheEnd.cs
@@ -22,7 +22,7 @@ namespace CalamityEntropy.Content.Items.Weapons
         {
             Item.width = 50;
             Item.height = 38;
-            Item.damage = 3000;
+            Item.damage = 2800;
             Item.noMelee = true;
             Item.noUseGraphic = true;
             Item.useAnimation = Item.useTime = 15;

--- a/Content/Items/Weapons/TheDeadCut.cs
+++ b/Content/Items/Weapons/TheDeadCut.cs
@@ -18,7 +18,7 @@ namespace CalamityEntropy.Content.Items.Weapons
         {
             Item.width = 98;
             Item.height = 88;
-            Item.damage = 336;
+            Item.damage = 180;
             Item.noMelee = true;
             Item.noUseGraphic = true;
             Item.useAnimation = Item.useTime = 16;


### PR DESCRIPTION
内容:
1.分型面板改为40（可以一路杀到骷髅王，仅次于神器锤子鱼，而且打邪恶t2更加安全）
2.虚妄切迹者面板改为180（依然能够轻松蒸发风吞和虚空，近战切老核弹成绩优秀）
3.启示录面板改为115，使用时间变为20（月前最强常规贼武器，恶意月总指定解）
4.降低演算宝珠的掉落率（强力饰品值得多刷）
5.蜜蜂弹：面板8-2，蜜蜂箭：面板8-4，凝元弹：面板3-1（这些子弹都有些太强了甚至可以和花后乃至月后弹药抗衡，给予适当削弱）
6.提升的虚空之触的减速强度，以目前版本的速度可以出圈飙车，这个改动旨在限制这种打法
7.删除终与始的穿甲，面板提升至2800，使用时间降低至15，以抗衡绯红恶魔（毕竟盗贼吃不到激怒不是吗）