### PR TITLE
更改补充（有一些内容和红茶的优化冲突了所以再红茶提交代码的基础上重新改了一遍）

### DIFF
--- a/Content/Items/Ammo/HiveArrow.cs
+++ b/Content/Items/Ammo/HiveArrow.cs
@@ -16,7 +16,7 @@ namespace CalamityEntropy.Content.Items.Ammo
         {
             Item.width = 14;
             Item.height = 36;
-            Item.damage = 8;
+            Item.damage = 4;
             Item.DamageType = DamageClass.Ranged;
             Item.rare = ItemRarityID.Orange;
             Item.maxStack = Item.CommonMaxStack;

--- a/Content/Items/Ammo/HiveBullet.cs
+++ b/Content/Items/Ammo/HiveBullet.cs
@@ -15,7 +15,7 @@ namespace CalamityEntropy.Content.Items.Ammo
 
         public override void SetDefaults()
         {
-            Item.damage = 4;
+            Item.damage = 2;
             Item.DamageType = DamageClass.Ranged;
             Item.width = 8;
             Item.height = 8;

--- a/Content/Items/Ammo/HiveBullet.cs
+++ b/Content/Items/Ammo/HiveBullet.cs
@@ -15,7 +15,7 @@ namespace CalamityEntropy.Content.Items.Ammo
 
         public override void SetDefaults()
         {
-            Item.damage = 8;
+            Item.damage = 4;
             Item.DamageType = DamageClass.Ranged;
             Item.width = 8;
             Item.height = 8;

--- a/Content/Items/ProphetBag.cs
+++ b/Content/Items/ProphetBag.cs
@@ -57,7 +57,7 @@ namespace CalamityEntropy.Content.Items
             itemLoot.Add(ModContent.ItemType<SpiritBanner>(), new Fraction(4, 5));
             itemLoot.Add(ModContent.ItemType<RuneMachineGun>(), new Fraction(4, 5));
             itemLoot.Add(ModContent.ItemType<ProphecyFlyingKnife>(), new Fraction(4, 5));
-            itemLoot.Add(ModContent.ItemType<ForeseeOrb>(), new Fraction(4, 5));
+            itemLoot.Add(ModContent.ItemType<ForeseeOrb>(), new Fraction(1, 4));
             itemLoot.Add(ModContent.ItemType<RuneWing>(), new Fraction(4, 5));
             itemLoot.Add(ModContent.ItemType<BookMarkForesee>(), new Fraction(2, 5));
         }

--- a/Content/Items/Weapons/Fractal/ShatteredFractal.cs
+++ b/Content/Items/Weapons/Fractal/ShatteredFractal.cs
@@ -24,7 +24,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Fractal
     {
         public override void SetDefaults()
         {
-            Item.damage = 46;
+            Item.damage = 40;
             Item.crit = 3;
             Item.DamageType = ModContent.GetInstance<TrueMeleeDamageClass>();
             Item.width = 48;

--- a/Content/Items/Weapons/Fractal/WelkinFractal.cs
+++ b/Content/Items/Weapons/Fractal/WelkinFractal.cs
@@ -24,7 +24,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Fractal
     {
         public override void SetDefaults()
         {
-            Item.damage = 70;
+            Item.damage = 40;
             Item.crit = 3;
             Item.DamageType = ModContent.GetInstance<TrueMeleeDamageClass>();
             Item.width = 48;

--- a/Content/Items/Weapons/Revelation.cs
+++ b/Content/Items/Weapons/Revelation.cs
@@ -17,10 +17,10 @@ namespace CalamityEntropy.Content.Items.Weapons
         {
             Item.width = 36;
             Item.height = 34;
-            Item.damage = 116;
+            Item.damage = 100;
             Item.noMelee = true;
             Item.noUseGraphic = true;
-            Item.useAnimation = Item.useTime = 16;
+            Item.useAnimation = Item.useTime = 20;
             Item.useStyle = ItemUseStyleID.Swing;
             Item.knockBack = 1f;
             Item.UseSound = SoundID.Item1;

--- a/Content/Items/Weapons/TheBeginingAndTheEnd.cs
+++ b/Content/Items/Weapons/TheBeginingAndTheEnd.cs
@@ -22,11 +22,11 @@ namespace CalamityEntropy.Content.Items.Weapons
         {
             Item.width = 50;
             Item.height = 38;
-            Item.damage = 2400;
+            Item.damage = 2800;
             Item.ArmorPenetration = 80;
             Item.noMelee = true;
             Item.noUseGraphic = true;
-            Item.useAnimation = Item.useTime = 20;
+            Item.useAnimation = Item.useTime = 15;
             Item.useStyle = ItemUseStyleID.Swing;
             Item.ArmorPenetration = 86;
             Item.knockBack = 1f;

--- a/Content/Items/Weapons/TheDeadCut.cs
+++ b/Content/Items/Weapons/TheDeadCut.cs
@@ -18,7 +18,7 @@ namespace CalamityEntropy.Content.Items.Weapons
         {
             Item.width = 98;
             Item.height = 88;
-            Item.damage = 336;
+            Item.damage = 180;
             Item.noMelee = true;
             Item.noUseGraphic = true;
             Item.useAnimation = Item.useTime = 16;


### PR DESCRIPTION
内容:
1.分型
  破碎分型面板改为40
（40面板是反复测试出来的t2邪恶前合理极限，这个面板可以杀穿大死前期，使战士拥有海蛇尾召唤的暴力输出）
  苍穹分型面板降低为40
（一样的，40面板可以保证苍穹分型是除虚锋以外的骷髅王蜂王最优解，天蓝套配合肾上腺素可以秒杀骷髅王3阶段，70面板太高以至于可以打肉后了）

2.虚妄切迹者面板改为180
（180面板的虚切更加符合它的时期定位，对同为使徒的风吞西哥依旧是神前最强，风吞只要开甲5个潜伏就能蒸，打神吞龙啥的还是留给后面的武器吧）

3.启示录面板改为100，使用时间变为20
（削了不是废了，半肉对恶意月总稳定3000秒伤，依旧强大，调整之前过强到可以打幽花）

4.降低演算宝珠的掉落率为25%
（强力饰品需要适当花费精力刷取，合理）

5.蜜蜂弹：面板8-2，蜜蜂箭：面板8-4，
（蜜蜂弹2面板不至于和树妖之泪这种花后子弹不相上下了，蜜蜂箭4面板不至于可以一直干翻花前所有箭矢了）

6.终与始面板提升至2800，使用时间降低至15
（只有达到这个数值，才能使它在对抗虚无化身和无名光神的战斗中的优先级高于绯红恶魔，毕业盗贼武器需要超过一定的平均水准以缩小因为无法穿魔影套而落下的伤害）

7.关于熵书我没动，但是目前收集到的情况包括：多个吸血书页永远不死，穿透书页搭配追踪高频反复判定单目标打出荒谬输出，多人联机无法看见队友使用书页，还有使用书会导致极端卡顿等问题