### PR TITLE
1.6版本的新的一些平衡性调整

### DIFF
--- a/Content/Buffs/VoidTouch.cs
+++ b/Content/Buffs/VoidTouch.cs
@@ -27,7 +27,7 @@ namespace CalamityEntropy.Content.Buffs
         {
             if (Main.GameUpdateCount % 20 == 0 && player.Entropy().voidResistance < 1)
             {
-                int dmg = (int)(player.Entropy().voidResistance * 12);
+                int dmg = (int)(player.Entropy().voidResistance * 16);
                 player.statLife -= dmg;
                 if (player.statLife <= dmg)
                 {

--- a/Content/Items/CruiserBag.cs
+++ b/Content/Items/CruiserBag.cs
@@ -63,7 +63,7 @@ namespace CalamityEntropy.Content.Items
             itemLoot.Add(ModContent.ItemType<WindOfUndertaker>(), new Fraction(1, 5));
             itemLoot.Add(ModContent.ItemType<VoidToy>(), new Fraction(1, 5));
             itemLoot.Add(ModContent.ItemType<CruiserPlush>(), new Fraction(1, 6));
-            itemLoot.Add(ModContent.ItemType<VoidScales>(), new Fraction(1, 1), 140, 162);
+            itemLoot.Add(ModContent.ItemType<VoidScales>(), new Fraction(1, 1), 35, 48);
             itemLoot.Add(ItemDropRule.ByCondition(new IsDeathMode(), ModContent.ItemType<TheocracyPearlToy>(), 5));
 
             itemLoot.Add(ModContent.ItemType<VoidMonolith>(), new Fraction(2, 5));

--- a/Content/Items/Weapons/LashingBramblerod.cs
+++ b/Content/Items/Weapons/LashingBramblerod.cs
@@ -23,7 +23,7 @@ namespace CalamityEntropy.Content.Items.Weapons
         }
         public override void SetDefaults()
         {
-            Item.DefaultToWhip(ModContent.ProjectileType<LashingBramblerodProjectile>(), 80, 3, 4, 36);
+            Item.DefaultToWhip(ModContent.ProjectileType<LashingBramblerodProjectile>(), 80, 3, 4, 60);
             Item.rare = ItemRarityID.Yellow;
             Item.value = CalamityGlobalItem.RarityYellowBuyPrice;
             Item.autoReuse = true;

--- a/Content/Items/Weapons/RuneMachineGun.cs
+++ b/Content/Items/Weapons/RuneMachineGun.cs
@@ -21,10 +21,10 @@ namespace CalamityEntropy.Content.Items.Weapons
         {
             Item.width = 100;
             Item.height = 70;
-            Item.damage = 26;
+            Item.damage = 10;
             Item.DamageType = DamageClass.Ranged;
-            Item.useTime = 4;
-            Item.useAnimation = 12;
+            Item.useTime = 6;
+            Item.useAnimation = 6;
             Item.useStyle = ItemUseStyleID.Shoot;
             Item.noMelee = true;
             Item.knockBack = 2f;
@@ -37,7 +37,7 @@ namespace CalamityEntropy.Content.Items.Weapons
             Item.useAmmo = AmmoID.Bullet;
             Item.crit = 8;
             Item.Calamity().canFirePointBlankShots = true;
-            Item.ArmorPenetration = 54;
+            Item.ArmorPenetration = 50;
         }
         public override Vector2? HoldoutOffset()
         {

--- a/Content/Items/Weapons/Silence.cs
+++ b/Content/Items/Weapons/Silence.cs
@@ -17,12 +17,12 @@ namespace CalamityEntropy.Content.Items.Weapons
         {
             Item.width = 36;
             Item.height = 34;
-            Item.damage = 280;
+            Item.damage = 360;
             Item.noMelee = true;
             Item.noUseGraphic = true;
             Item.useAnimation = Item.useTime = 14;
             Item.useStyle = ItemUseStyleID.Swing;
-            Item.ArmorPenetration = 30;
+            Item.ArmorPenetration = 50;
             Item.knockBack = 1f;
             Item.UseSound = SoundID.Item1;
             Item.autoReuse = true;

--- a/Content/Items/Weapons/Ystralyn.cs
+++ b/Content/Items/Weapons/Ystralyn.cs
@@ -16,7 +16,7 @@ namespace CalamityEntropy.Content.Items.Weapons
         public static int PhantomDamage = 1800;
         public override void SetDefaults()
         {
-            Item.DefaultToWhip(ModContent.ProjectileType<YstralynProj>(), 360, 2, 4, 27);
+            Item.DefaultToWhip(ModContent.ProjectileType<YstralynProj>(), 600, 2, 4, 27);
             Item.rare = ModContent.RarityType<AbyssalBlue>();
             Item.value = CalamityGlobalItem.RarityCalamityRedBuyPrice;
             Item.autoReuse = true;

--- a/Content/NPCs/Cruiser/CruiserHead.cs
+++ b/Content/NPCs/Cruiser/CruiserHead.cs
@@ -116,29 +116,29 @@ namespace CalamityEntropy.Content.NPCs.Cruiser
         public override void SetDefaults()
         {
             NPC.Calamity().canBreakPlayerDefense = true;
-            NPC.Calamity().DR = 0.3f;
+            NPC.Calamity().DR = 0.40f;
             NPC.boss = true;
             NPC.width = 100;
             NPC.height = 100;
-            NPC.damage = 180;
+            NPC.damage = 190;
             if (Main.expertMode)
             {
-                NPC.damage += 10;
+                NPC.damage += 15;
             }
             if (Main.masterMode)
             {
-                NPC.damage += 10;
+                NPC.damage += 5;
             }
             NPC.defense = 100;
             NPC.lifeMax = 1200000;
             if (CalamityWorld.death)
             {
-                NPC.damage += 24;
+                NPC.damage += 20;
                 length += 4;
             }
             else if (CalamityWorld.revenge)
             {
-                NPC.damage += 18;
+                NPC.damage += 20;
                 length += 2;
             }
             tdamage = NPC.damage;


### PR DESCRIPTION
1.蔓生棘鞭：使用时间增加到60（适当限制其叠加免伤的效果，打石巨人依然专业对口）

2.符文之歌：面板降低到10，usetime=useanimation=6，穿甲降低到50（考虑到先知难度目前降低到星舰相近水准的修改，即便如此，符文之歌的强度依然碾压歌莉娅前所有射手武器，强度接近四柱武器）

3.妖龙鞭子：面板提升到600

4.使巡游者宝藏袋里开出鳞片的数目合理化（35到48个）（计算得，一个单人档一般所需要的虚渺锭数目为140个，即大约30个鳞片，现在巡游者掉一百多个鳞片过多了其实）

5.沉默：面板提升至360，穿甲提升至50（考虑到巡游者加强做出的改动，使其有足以对抗古泽玛和至尊灾厄的输出）

6.巡游者伤害数值回调，大师模式伤害降低，专家模式伤害提高，复仇死亡伤害加成一致，免伤提升（现在巡游又可以被硫酸炮当狗打了，大死的弹幕甚至两下破不了海绵盾，应该适当加强）

7.虚空之触对玩家伤害提升33%(由于虚空之触不禁回血所以现在的真实伤害甚至不如神圣之火，当提升减益数值)