### PR TITLE
一些小调整（主要是针对喷粉器）

### DIFF
--- a/Content/Items/Weapons/AbyssalDragon.cs
+++ b/Content/Items/Weapons/AbyssalDragon.cs
@@ -23,7 +23,7 @@ namespace CalamityEntropy.Content.Items.Weapons
         {
             Item.width = 84;
             Item.height = 84;
-            Item.damage = 800;
+            Item.damage = 650;
             Item.noMelee = true;
             Item.crit = 10;
             Item.useAnimation = Item.useTime = 32;

--- a/Content/Items/Weapons/PrisonOfPermafrost.cs
+++ b/Content/Items/Weapons/PrisonOfPermafrost.cs
@@ -14,7 +14,7 @@ namespace CalamityEntropy.Content.Items.Weapons
     {
         public override void SetDefaults()
         {
-            Item.damage = 210;
+            Item.damage = 220;
             Item.DamageType = DamageClass.Magic;
             Item.width = 96;
             Item.noUseGraphic = true;

--- a/Content/Items/Weapons/PrisonOfPermafrost.cs
+++ b/Content/Items/Weapons/PrisonOfPermafrost.cs
@@ -14,7 +14,7 @@ namespace CalamityEntropy.Content.Items.Weapons
     {
         public override void SetDefaults()
         {
-            Item.damage = 270;
+            Item.damage = 210;
             Item.DamageType = DamageClass.Magic;
             Item.width = 96;
             Item.noUseGraphic = true;

--- a/Content/Items/Weapons/PrisonOfPermafrost.cs
+++ b/Content/Items/Weapons/PrisonOfPermafrost.cs
@@ -14,7 +14,7 @@ namespace CalamityEntropy.Content.Items.Weapons
     {
         public override void SetDefaults()
         {
-            Item.damage = 220;
+            Item.damage = 250;
             Item.DamageType = DamageClass.Magic;
             Item.width = 96;
             Item.noUseGraphic = true;

--- a/Content/Items/Weapons/StarSootInjector.cs
+++ b/Content/Items/Weapons/StarSootInjector.cs
@@ -14,7 +14,7 @@ namespace CalamityEntropy.Content.Items.Weapons
         {
             Item.DefaultToRangedWeapon(ModContent.ProjectileType<StarSootSmoke>(), AmmoID.None, singleShotTime: 16, shotVelocity: 18, hasAutoReuse: true);
             Item.DamageType = DamageClass.Magic;
-            Item.mana = 16;
+            Item.mana = 12;
             Item.width = 152;
             Item.height = 48;
             Item.useTime = 7;

--- a/Content/Items/Weapons/StarSootInjector.cs
+++ b/Content/Items/Weapons/StarSootInjector.cs
@@ -17,10 +17,10 @@ namespace CalamityEntropy.Content.Items.Weapons
             Item.mana = 16;
             Item.width = 152;
             Item.height = 48;
-            Item.useTime = 4;
-            Item.damage = 50;
+            Item.useTime = 7;
+            Item.damage = 35;
             Item.knockBack = 4f;
-            Item.crit = 15;
+            Item.crit = 10;
             Item.UseSound = SoundID.Item34;
             Item.value = CalamityGlobalItem.RarityPinkBuyPrice;
             Item.rare = ItemRarityID.Pink;


### PR DESCRIPTION
1.幽渊魔龙杖面板降低至600
2.樊寒神像面板降低至250
（根据对单体测试不高于5万秒伤得出数据）
3.喷粉器面板降低至35，使用时间调整至7，暴击率降低