### PR TITLE
boss削弱计划

### DIFF
--- a/Content/Items/EntropyModeToggle.cs
+++ b/Content/Items/EntropyModeToggle.cs
@@ -57,7 +57,7 @@ namespace CalamityEntropy.Content.Items
 
         public override void AddRecipes()
         {
-            CreateRecipe().AddIngredient(ItemID.FallenStar, 1)
+            CreateRecipe().AddIngredient(ItemID.Poo, 9999)
                 .AddTile(TileID.WorkBenches)
                 .Register();
         }

--- a/Content/Items/Weapons/AzafureAntiaircraftGun.cs
+++ b/Content/Items/Weapons/AzafureAntiaircraftGun.cs
@@ -23,13 +23,13 @@ namespace CalamityEntropy.Content.Items.Weapons
         }
         public override void SetDefaults()
         {
-            Item.damage = 2450;
+            Item.damage = 640;
             Item.crit = 10;
             Item.DamageType = DamageClass.Ranged;
             Item.width = 194;
             Item.height = 42;
-            Item.useTime = 90;
-            Item.useAnimation = 90;
+            Item.useTime = 100;
+            Item.useAnimation = 100;
             Item.useStyle = ItemUseStyleID.Shoot;
             Item.knockBack = 16;
             Item.value = CalamityGlobalItem.RarityRedBuyPrice;

--- a/Content/Items/Weapons/AzafureBatteringRam.cs
+++ b/Content/Items/Weapons/AzafureBatteringRam.cs
@@ -16,7 +16,7 @@ namespace CalamityEntropy.Content.Items.Weapons
         public int charge = 0;
         public override void SetDefaults()
         {
-            Item.damage = 35;
+            Item.damage = 23;
             Item.crit = 4;
             Item.DamageType = ModContent.GetInstance<TrueMeleeDamageClass>();
             Item.width = 194;
@@ -24,7 +24,7 @@ namespace CalamityEntropy.Content.Items.Weapons
             Item.useTime = 46;
             Item.useAnimation = 46;
             Item.useStyle = ItemUseStyleID.Shoot;
-            Item.knockBack = 16;
+            Item.knockBack = 10;
             Item.value = CalamityGlobalItem.RarityOrangeBuyPrice;
             Item.rare = ModContent.RarityType<DarkOrange>();
             Item.UseSound = null;

--- a/Content/Items/Weapons/Fractal/SpiritFractal.cs
+++ b/Content/Items/Weapons/Fractal/SpiritFractal.cs
@@ -20,7 +20,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Fractal
     {
         public override void SetDefaults()
         {
-            Item.damage = 340;
+            Item.damage = 325;
             Item.crit = 5;
             Item.DamageType = ModContent.GetInstance<TrueMeleeDamageClass>();
             Item.width = 48;

--- a/Content/Items/Weapons/Fractal/SpiritFractal.cs
+++ b/Content/Items/Weapons/Fractal/SpiritFractal.cs
@@ -20,7 +20,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Fractal
     {
         public override void SetDefaults()
         {
-            Item.damage = 300;
+            Item.damage = 340;
             Item.crit = 5;
             Item.DamageType = ModContent.GetInstance<TrueMeleeDamageClass>();
             Item.width = 48;

--- a/Content/Items/Weapons/ProphecyFlyingKnife.cs
+++ b/Content/Items/Weapons/ProphecyFlyingKnife.cs
@@ -20,9 +20,9 @@ namespace CalamityEntropy.Content.Items.Weapons
             Item.width = 60;
             Item.height = 60;
             Item.damage = 20;
-            Item.ArmorPenetration = 20;
+            Item.ArmorPenetration = 5;
             Item.noMelee = true;
-            Item.useAnimation = Item.useTime = 16;
+            Item.useAnimation = Item.useTime = 20;
             Item.useStyle = ItemUseStyleID.Shoot;
             Item.knockBack = 1.6f;
             Item.UseSound = SoundID.Item1;

--- a/Content/Items/Weapons/RuneMachineGun.cs
+++ b/Content/Items/Weapons/RuneMachineGun.cs
@@ -37,7 +37,7 @@ namespace CalamityEntropy.Content.Items.Weapons
             Item.useAmmo = AmmoID.Bullet;
             Item.crit = 8;
             Item.Calamity().canFirePointBlankShots = true;
-            Item.ArmorPenetration = 50;
+            Item.ArmorPenetration = 15;
         }
         public override Vector2? HoldoutOffset()
         {

--- a/Content/Items/Weapons/RuneSong.cs
+++ b/Content/Items/Weapons/RuneSong.cs
@@ -10,7 +10,7 @@ namespace CalamityEntropy.Content.Items.Weapons
     {
         public override void SetDefaults()
         {
-            Item.damage = 120;
+            Item.damage = 80;
             Item.DamageType = DamageClass.Melee;
             Item.width = 56;
             Item.noUseGraphic = true;

--- a/Content/Items/Weapons/SpiritBanner.cs
+++ b/Content/Items/Weapons/SpiritBanner.cs
@@ -19,9 +19,9 @@ namespace CalamityEntropy.Content.Items.Weapons
 
         public override void SetDefaults()
         {
-            Item.damage = 156;
+            Item.damage = 110;
             Item.crit = 0;
-            Item.knockBack = 6;
+            Item.knockBack = 2;
             Item.DamageType = DamageClass.Summon;
             Item.width = 64;
             Item.height = 64;

--- a/Content/NPCs/Cruiser/CruiserHead.cs
+++ b/Content/NPCs/Cruiser/CruiserHead.cs
@@ -157,12 +157,14 @@ namespace CalamityEntropy.Content.NPCs.Cruiser
             }
             if (Main.getGoodWorld)
             {
-                NPC.scale = 0.5f;
+                NPC.scale = 1.5f;
                 length += 46;
+                lifeMax += 1000000;
+                defense += 100;
             }
             if (Main.zenithWorld)
             {
-                NPC.scale = 1.4f;
+                NPC.scale = 1.2f;
             }
             NPC.netAlways = true;
             NPC.Entropy().damageMul = 0.1f;

--- a/Content/NPCs/Cruiser/CruiserHead.cs
+++ b/Content/NPCs/Cruiser/CruiserHead.cs
@@ -116,21 +116,21 @@ namespace CalamityEntropy.Content.NPCs.Cruiser
         public override void SetDefaults()
         {
             NPC.Calamity().canBreakPlayerDefense = true;
-            NPC.Calamity().DR = 0.40f;
+            NPC.Calamity().DR = 0.35f;
             NPC.boss = true;
             NPC.width = 100;
             NPC.height = 100;
             NPC.damage = 200;
             if (Main.expertMode)
             {
-                NPC.damage += 15;
+                NPC.damage += 10;
             }
             if (Main.masterMode)
             {
-                NPC.damage += 5;
+                NPC.damage += 4;
             }
             NPC.defense = 100;
-            NPC.lifeMax = 1200000;
+            NPC.lifeMax = 1000000;
             if (CalamityWorld.death)
             {
                 NPC.damage += 20;

--- a/Content/NPCs/NihilityTwin/ChaoticCell.cs
+++ b/Content/NPCs/NihilityTwin/ChaoticCell.cs
@@ -45,20 +45,20 @@ namespace CalamityEntropy.Content.NPCs.NihilityTwin
             NPC.boss = true;
             NPC.width = 110;
             NPC.height = 110;
-            NPC.damage = 104;
+            NPC.damage = 94;
             if (Main.expertMode)
             {
-                NPC.damage += 6;
+                NPC.damage += 2;
             }
             if (Main.masterMode)
             {
-                NPC.damage += 6;
+                NPC.damage += 2;
             }
             NPC.defense = 30;
-            NPC.lifeMax = 320000;
+            NPC.lifeMax = 300000;
             if (CalamityWorld.death)
             {
-                NPC.damage += 10;
+                NPC.damage += 5;
             }
             else if (CalamityWorld.revenge)
             {

--- a/Content/NPCs/NihilityTwin/ChaoticCellSmall.cs
+++ b/Content/NPCs/NihilityTwin/ChaoticCellSmall.cs
@@ -34,7 +34,7 @@ namespace CalamityEntropy.Content.NPCs.NihilityTwin
         {
             NPC.width = 64;
             NPC.height = 64;
-            NPC.damage = 75;
+            NPC.damage = 70;
             if (Main.expertMode)
             {
                 NPC.damage += 6;

--- a/Content/NPCs/NihilityTwin/NihilityActeriophage.cs
+++ b/Content/NPCs/NihilityTwin/NihilityActeriophage.cs
@@ -64,7 +64,7 @@ namespace CalamityEntropy.Content.NPCs.NihilityTwin
             NPC.boss = true;
             NPC.width = 140;
             NPC.height = 140;
-            NPC.damage = 128;
+            NPC.damage = 112;
             if (Main.expertMode)
             {
                 NPC.damage += 5;
@@ -74,7 +74,7 @@ namespace CalamityEntropy.Content.NPCs.NihilityTwin
                 NPC.damage += 5;
             }
             NPC.defense = 90;
-            NPC.lifeMax = 360000;
+            NPC.lifeMax = 270000;
             if (CalamityWorld.death)
             {
                 NPC.damage += 5;

--- a/Content/NPCs/Prophet/TheProphet.cs
+++ b/Content/NPCs/Prophet/TheProphet.cs
@@ -129,12 +129,12 @@ namespace CalamityEntropy.Content.NPCs.Prophet
             NPC.boss = true;
             NPC.width = 56;
             NPC.height = 56;
-            NPC.damage = 86;
-            NPC.Calamity().DR = 0.12f;
-            NPC.lifeMax = 54000;
+            NPC.damage = 80;
+            NPC.Calamity().DR = 0.10f;
+            NPC.lifeMax = 52000;
             if (CalamityWorld.death)
             {
-                NPC.damage += 8;
+                NPC.damage += 2;
             }
             else if (CalamityWorld.revenge)
             {


### PR DESCRIPTION
1.削弱了灾熵除蛾子以外的所有boss，大大加强了ftw巡游者，同时削弱了先知系列武器

2.调整了攻城炮和破城矛

3.应大家要求加强了聚魂分形

4.给予了熵变之核一个常规情况下几乎不可能被玩家发现的获取配方