### PR TITLE
熵书和虚无双子调整（根据锯角反馈）

### DIFF
--- a/Content/Buffs/VoidVirus.cs
+++ b/Content/Buffs/VoidVirus.cs
@@ -39,9 +39,9 @@ namespace CalamityEntropy.Content.Buffs
 
             if (Main.GameUpdateCount % 12 == 0)
             {
-                if (player.statLife > 5)
+                if (player.statLife > 2)
                 {
-                    player.statLife -= 5;
+                    player.statLife -= 2;
                 }
                 else
                 {
@@ -57,7 +57,7 @@ namespace CalamityEntropy.Content.Buffs
         {
             if (npc.HasBuff<VoidVirus>())
             {
-                modifiers.ArmorPenetration += 20;
+                modifiers.ArmorPenetration += 10;
             }
         }
     }

--- a/Content/Items/Ammo/HiveArrow.cs
+++ b/Content/Items/Ammo/HiveArrow.cs
@@ -16,7 +16,7 @@ namespace CalamityEntropy.Content.Items.Ammo
         {
             Item.width = 14;
             Item.height = 36;
-            Item.damage = 5;
+            Item.damage = 2;
             Item.DamageType = DamageClass.Ranged;
             Item.rare = ItemRarityID.Orange;
             Item.maxStack = Item.CommonMaxStack;

--- a/Content/Items/Ammo/HiveBullet.cs
+++ b/Content/Items/Ammo/HiveBullet.cs
@@ -15,7 +15,7 @@ namespace CalamityEntropy.Content.Items.Ammo
 
         public override void SetDefaults()
         {
-            Item.damage = 3;
+            Item.damage = 1;
             Item.DamageType = DamageClass.Ranged;
             Item.width = 8;
             Item.height = 8;

--- a/Content/Items/Books/BurntLostClassics.cs
+++ b/Content/Items/Books/BurntLostClassics.cs
@@ -14,12 +14,12 @@ namespace CalamityEntropy.Content.Items.Books
         public override void SetDefaults()
         {
             base.SetDefaults();
-            Item.damage = 30;
+            Item.damage = 48;
             Item.useAnimation = Item.useTime = 20;
             Item.crit = 5;
             Item.mana = 6;
             Item.shootSpeed = 10;
-            Item.ArmorPenetration = 16;
+            Item.ArmorPenetration = 20;
         }
         public override Texture2D BookMarkTexture => ModContent.Request<Texture2D>("CalamityEntropy/Content/UI/EntropyBookUI/BLC").Value;
         public override int HeldProjectileType => ModContent.ProjectileType<BurntLostClassicsHeld>();

--- a/Content/Items/Books/BurntLostClassics.cs
+++ b/Content/Items/Books/BurntLostClassics.cs
@@ -14,7 +14,7 @@ namespace CalamityEntropy.Content.Items.Books
         public override void SetDefaults()
         {
             base.SetDefaults();
-            Item.damage = 48;
+            Item.damage = 45;
             Item.useAnimation = Item.useTime = 20;
             Item.crit = 5;
             Item.mana = 6;

--- a/Content/Items/Books/UpdraftTome.cs
+++ b/Content/Items/Books/UpdraftTome.cs
@@ -12,8 +12,8 @@ namespace CalamityEntropy.Content.Items.Books
         public override void SetDefaults()
         {
             base.SetDefaults();
-            Item.damage = 24;
-            Item.useAnimation = Item.useTime = 20;
+            Item.damage = 60;
+            Item.useAnimation = Item.useTime = 50;
             Item.crit = 5;
             Item.mana = 6;
         }

--- a/Content/Items/Books/UpdraftTome.cs
+++ b/Content/Items/Books/UpdraftTome.cs
@@ -12,7 +12,7 @@ namespace CalamityEntropy.Content.Items.Books
         public override void SetDefaults()
         {
             base.SetDefaults();
-            Item.damage = 58;
+            Item.damage = 24;
             Item.useAnimation = Item.useTime = 20;
             Item.crit = 5;
             Item.mana = 6;

--- a/Content/Items/Books/VoidOde.cs
+++ b/Content/Items/Books/VoidOde.cs
@@ -14,8 +14,8 @@ namespace CalamityEntropy.Content.Items.Books
         public override void SetDefaults()
         {
             base.SetDefaults();
-            Item.damage = 120;
-            Item.useAnimation = Item.useTime = 6;
+            Item.damage = 180;
+            Item.useAnimation = Item.useTime = 11;
             Item.crit = 10;
             Item.mana = 8;
             Item.shootSpeed = 44;

--- a/Content/NPCs/NihilityTwin/ChaoticCell.cs
+++ b/Content/NPCs/NihilityTwin/ChaoticCell.cs
@@ -45,7 +45,7 @@ namespace CalamityEntropy.Content.NPCs.NihilityTwin
             NPC.boss = true;
             NPC.width = 110;
             NPC.height = 110;
-            NPC.damage = 94;
+            NPC.damage = 85;
             if (Main.expertMode)
             {
                 NPC.damage += 2;
@@ -55,7 +55,7 @@ namespace CalamityEntropy.Content.NPCs.NihilityTwin
                 NPC.damage += 2;
             }
             NPC.defense = 30;
-            NPC.lifeMax = 300000;
+            NPC.lifeMax = 270000;
             if (CalamityWorld.death)
             {
                 NPC.damage += 5;

--- a/Content/NPCs/NihilityTwin/ChaoticCellSmall.cs
+++ b/Content/NPCs/NihilityTwin/ChaoticCellSmall.cs
@@ -34,23 +34,23 @@ namespace CalamityEntropy.Content.NPCs.NihilityTwin
         {
             NPC.width = 64;
             NPC.height = 64;
-            NPC.damage = 70;
+            NPC.damage = 1;
             if (Main.expertMode)
             {
-                NPC.damage += 6;
+                NPC.damage += 1;
             }
             if (Main.masterMode)
             {
-                NPC.damage += 6;
+                NPC.damage += 1;
             }
             NPC.lifeMax = 2200;
             if (CalamityWorld.death)
             {
-                NPC.damage += 10;
+                NPC.damage += 1;
             }
             else if (CalamityWorld.revenge)
             {
-                NPC.damage += 8;
+                NPC.damage += 1;
             }
             NPC.HitSound = SoundID.NPCHit1;
             NPC.DeathSound = SoundID.NPCHit1;

--- a/Content/NPCs/NihilityTwin/NihilityActeriophage.cs
+++ b/Content/NPCs/NihilityTwin/NihilityActeriophage.cs
@@ -64,7 +64,7 @@ namespace CalamityEntropy.Content.NPCs.NihilityTwin
             NPC.boss = true;
             NPC.width = 140;
             NPC.height = 140;
-            NPC.damage = 112;
+            NPC.damage = 100;
             if (Main.expertMode)
             {
                 NPC.damage += 5;
@@ -73,7 +73,7 @@ namespace CalamityEntropy.Content.NPCs.NihilityTwin
             {
                 NPC.damage += 5;
             }
-            NPC.defense = 90;
+            NPC.defense = 75;
             NPC.lifeMax = 270000;
             if (CalamityWorld.death)
             {

--- a/Content/NPCs/Prophet/TheProphet.cs
+++ b/Content/NPCs/Prophet/TheProphet.cs
@@ -129,7 +129,7 @@ namespace CalamityEntropy.Content.NPCs.Prophet
             NPC.boss = true;
             NPC.width = 56;
             NPC.height = 56;
-            NPC.damage = 80;
+            NPC.damage = 70;
             NPC.Calamity().DR = 0.10f;
             NPC.lifeMax = 52000;
             if (CalamityWorld.death)


### PR DESCRIPTION
1.削弱了虚空病毒减益和虚无双子，降低难度
2.削弱了升流古书，它现在更偏向于辅助武器；加强了焦灼遗编，它现在是巨著的单体对位；降低了虚空书的射速并加强了面板，削弱其上限
3.再次削弱了先知的伤害
4.削弱了蜜蜂弹和蜜蜂箭，使其更像是肉初弹药而非石后弹药