### PR TITLE
抽奖机清理与盔甲词条平衡：

### DIFF
--- a/Content/ArmorPrefixes/DestinedGreatness.cs
+++ b/Content/ArmorPrefixes/DestinedGreatness.cs
@@ -8,11 +8,11 @@ namespace CalamityEntropy.Content.ArmorPrefixes
         public override void UpdateEquip(Player player, Item item)
         {
             player.luck += 0.1f;
-            player.GetCritChance(DamageClass.Generic) += 4;
+            player.GetCritChance(DamageClass.Generic) += 2;
         }
         public override float AddDefense()
         {
-            return 0.1f;
+            return 0.05f;
         }
         public override int getRollChance()
         {

--- a/Content/ArmorPrefixes/End.cs
+++ b/Content/ArmorPrefixes/End.cs
@@ -7,8 +7,8 @@ namespace CalamityEntropy.Content.ArmorPrefixes
     {
         public override void UpdateEquip(Player player, Item item)
         {
-            player.GetDamage(DamageClass.Generic) += 0.1f;
-            player.GetCritChance(DamageClass.Generic) += 6;
+            player.GetDamage(DamageClass.Generic) += 0.05f;
+            player.GetCritChance(DamageClass.Generic) += 4;
             player.GetKnockback(DamageClass.Generic) += 0.2f;
             player.Entropy().Thorn += 1f;
             player.Entropy().AttackVoidTouch += 0.01f;

--- a/Content/ArmorPrefixes/Evoker.cs
+++ b/Content/ArmorPrefixes/Evoker.cs
@@ -8,6 +8,7 @@ namespace CalamityEntropy.Content.ArmorPrefixes
         public override void UpdateEquip(Player player, Item item)
         {
             player.maxMinions += 1;
+            player.GetDamage(DamageClass.Generic) -= 0.15f;
         }
         public override bool? canApplyTo(Item item)
         {

--- a/Content/ArmorPrefixes/Evoker.cs
+++ b/Content/ArmorPrefixes/Evoker.cs
@@ -1,5 +1,6 @@
 ﻿using CalamityMod;
 using Terraria;
+using Terraria.ModLoader;
 
 namespace CalamityEntropy.Content.ArmorPrefixes
 {

--- a/Content/ArmorPrefixes/GodForged.cs
+++ b/Content/ArmorPrefixes/GodForged.cs
@@ -7,12 +7,12 @@ namespace CalamityEntropy.Content.ArmorPrefixes
     {
         public override void UpdateEquip(Player player, Item item)
         {
-            player.Entropy().damageReduce += 0.02f;
-            player.GetDamage(DamageClass.Generic) += 0.04f;
+            player.Entropy().damageReduce += 0.01f;
+            player.GetDamage(DamageClass.Generic) += 0.03f;
         }
         public override float AddDefense()
         {
-            return 0.15f;
+            return 0.08f;
         }
         public override int getRollChance()
         {

--- a/Content/ArmorPrefixes/Great.cs
+++ b/Content/ArmorPrefixes/Great.cs
@@ -7,11 +7,11 @@ namespace CalamityEntropy.Content.ArmorPrefixes
     {
         public override void UpdateEquip(Player player, Item item)
         {
-            player.GetDamage(DamageClass.Generic) += 0.04f;
+            player.GetDamage(DamageClass.Generic) += 0.02f;
         }
         public override float AddDefense()
         {
-            return 0.12f;
+            return 0.05f;
         }
         public override int getRollChance()
         {

--- a/Content/ArmorPrefixes/Great.cs
+++ b/Content/ArmorPrefixes/Great.cs
@@ -11,7 +11,7 @@ namespace CalamityEntropy.Content.ArmorPrefixes
         }
         public override float AddDefense()
         {
-            return 0.05f;
+            return 0.08f;
         }
         public override int getRollChance()
         {

--- a/Content/ArmorPrefixes/Guarded.cs
+++ b/Content/ArmorPrefixes/Guarded.cs
@@ -10,7 +10,7 @@ namespace CalamityEntropy.Content.ArmorPrefixes
         }
         public override float AddDefense()
         {
-            return 0.2f;
+            return 0.15f;
         }
         public override int getRollChance()
         {

--- a/Content/ArmorPrefixes/LastStand.cs
+++ b/Content/ArmorPrefixes/LastStand.cs
@@ -7,12 +7,12 @@ namespace CalamityEntropy.Content.ArmorPrefixes
     {
         public override void UpdateEquip(Player player, Item item)
         {
-            player.Entropy().damageReduce += 0.05f;
+            player.Entropy().damageReduce += 0.02f;
             player.Entropy().LastStand = true;
         }
         public override float AddDefense()
         {
-            return 0.3f;
+            return 0.15f;
         }
         public override int getRollChance()
         {

--- a/Content/ArmorPrefixes/Light.cs
+++ b/Content/ArmorPrefixes/Light.cs
@@ -6,8 +6,8 @@ namespace CalamityEntropy.Content.ArmorPrefixes
     {
         public override void UpdateEquip(Player player, Item item)
         {
-            player.Entropy().moveSpeed += 0.1f;
-            player.Entropy().WingSpeed += 0.1f;
+            player.Entropy().moveSpeed += 0.03f;
+            player.Entropy().WingSpeed += 0.05f;
         }
     }
 }

--- a/Content/ArmorPrefixes/Magical.cs
+++ b/Content/ArmorPrefixes/Magical.cs
@@ -6,9 +6,9 @@ namespace CalamityEntropy.Content.ArmorPrefixes
     {
         public override void UpdateEquip(Player player, Item item)
         {
-            player.Entropy().ManaCost -= 0.1f;
-            player.statManaMax2 += 6;
-            player.Entropy().enhancedMana += 0.1f;
+            player.Entropy().ManaCost -= 0.05f;
+            player.statManaMax2 += 10;
+            player.Entropy().enhancedMana += 0.06f;
         }
         public override Color getColor()
         {

--- a/Content/ArmorPrefixes/Massive.cs
+++ b/Content/ArmorPrefixes/Massive.cs
@@ -6,11 +6,11 @@ namespace CalamityEntropy.Content.ArmorPrefixes
     {
         public override void UpdateEquip(Player player, Item item)
         {
-            player.Entropy().moveSpeed -= 0.15f;
+            player.Entropy().moveSpeed -= 0.30f;
         }
         public override float AddDefense()
         {
-            return 0.35f;
+            return 0.25f;
         }
         public override int getRollChance()
         {

--- a/Content/ArmorPrefixes/Miracle.cs
+++ b/Content/ArmorPrefixes/Miracle.cs
@@ -7,13 +7,12 @@ namespace CalamityEntropy.Content.ArmorPrefixes
     {
         public override void UpdateEquip(Player player, Item item)
         {
-            player.Entropy().damageReduce += 0.01f;
             player.Entropy().light += 0.4f;
-            player.GetDamage(DamageClass.Generic) += 0.04f;
+            player.GetDamage(DamageClass.Generic) += 0.02f;
         }
         public override float AddDefense()
         {
-            return 0.1f;
+            return 0.05f;
         }
         public override int getRollChance()
         {

--- a/Content/ArmorPrefixes/Reckless.cs
+++ b/Content/ArmorPrefixes/Reckless.cs
@@ -7,7 +7,7 @@ namespace CalamityEntropy.Content.ArmorPrefixes
     {
         public override void UpdateEquip(Player player, Item item)
         {
-            player.GetDamage(DamageClass.Generic) += 0.07f;
+            player.GetDamage(DamageClass.Generic) += 0.05f;
         }
         public override Color getColor()
         {
@@ -19,7 +19,7 @@ namespace CalamityEntropy.Content.ArmorPrefixes
         }
         public override float AddDefense()
         {
-            return -0.4f;
+            return -0.5f;
         }
     }
 }

--- a/Content/ArmorPrefixes/Sacrifical.cs
+++ b/Content/ArmorPrefixes/Sacrifical.cs
@@ -7,11 +7,11 @@ namespace CalamityEntropy.Content.ArmorPrefixes
     {
         public override void UpdateEquip(Player player, Item item)
         {
-            player.GetDamage(DamageClass.Generic) += 0.16f;
+            player.GetDamage(DamageClass.Generic) += 0.10f;
         }
         public override float AddDefense()
         {
-            return -0.7f;
+            return -0.99f;
         }
         public override int getRollChance()
         {

--- a/Content/ArmorPrefixes/Silence.cs
+++ b/Content/ArmorPrefixes/Silence.cs
@@ -8,7 +8,7 @@ namespace CalamityEntropy.Content.ArmorPrefixes
         public override void UpdateEquip(Player player, Item item)
         {
             player.Calamity().wearingRogueArmor = true;
-            player.Calamity().rogueStealthMax += 0.01f;
+            player.Calamity().rogueStealthMax += 0.02f;
         }
         public override Color getColor()
         {

--- a/Content/ArmorPrefixes/VoidTouched.cs
+++ b/Content/ArmorPrefixes/VoidTouched.cs
@@ -6,7 +6,7 @@ namespace CalamityEntropy.Content.ArmorPrefixes
     {
         public override void UpdateEquip(Player player, Item item)
         {
-            player.Entropy().AttackVoidTouch += 0.03f;
+            player.Entropy().AttackVoidTouch += 0.02f;
         }
         public override int getRollChance()
         {

--- a/Content/ArmorPrefixes/Wizard.cs
+++ b/Content/ArmorPrefixes/Wizard.cs
@@ -8,7 +8,7 @@ namespace CalamityEntropy.Content.ArmorPrefixes
     {
         public override void UpdateEquip(Player player, Item item)
         {
-            player.GetDamage(DamageClass.Summon) += 0.02f;
+            player.GetDamage(DamageClass.Summon) -= 0.10f;
             player.maxMinions += 1;
         }
         public override bool? canApplyTo(Item item)

--- a/Content/ArmorPrefixes/Wizard.cs
+++ b/Content/ArmorPrefixes/Wizard.cs
@@ -8,7 +8,7 @@ namespace CalamityEntropy.Content.ArmorPrefixes
     {
         public override void UpdateEquip(Player player, Item item)
         {
-            player.GetDamage(DamageClass.Summon) -= 0.10f;
+            player.GetDamage(DamageClass.Generic) -= 0.10f;
             player.maxMinions += 1;
         }
         public override bool? canApplyTo(Item item)

--- a/Content/Items/IllusionaryDew.cs
+++ b/Content/Items/IllusionaryDew.cs
@@ -52,7 +52,7 @@ namespace CalamityEntropy.Content.Items
             CreateRecipe().
                 AddIngredient(ModContent.ItemType<StarblightSoot>(), 6).
                 AddIngredient(ItemID.FallenStar, 2).
-                AddTile(TileID.DemonAltar).
+                AddTile(TileID.MythrilAnvil).
                 Register();
         }
     }

--- a/Content/Items/PrefixItem/PrefixItems.cs
+++ b/Content/Items/PrefixItem/PrefixItems.cs
@@ -48,6 +48,7 @@ namespace CalamityEntropy.Content.Items.PrefixItem
         {
             CreateRecipe().
                 AddIngredient<YharonSoulFragment>(1)
+                AddIngredient<AshesofAnnihilation>(1)
                 .AddIngredient<ExoPrism>(1)
                 .Register();
         }

--- a/Content/Items/PrefixItem/PrefixItems.cs
+++ b/Content/Items/PrefixItem/PrefixItems.cs
@@ -48,7 +48,7 @@ namespace CalamityEntropy.Content.Items.PrefixItem
         {
             CreateRecipe().
                 AddIngredient<YharonSoulFragment>(1)
-                AddIngredient<AshesofAnnihilation>(1)
+                .AddIngredient<AshesofAnnihilation>(1)
                 .AddIngredient<ExoPrism>(1)
                 .Register();
         }

--- a/Content/Items/ProphecyToken.cs
+++ b/Content/Items/ProphecyToken.cs
@@ -48,7 +48,7 @@ namespace CalamityEntropy.Content.Items
         {
             CreateRecipe().AddIngredient(ItemID.Book, 4)
                 .AddIngredient(ItemID.SoulofLight, 6)
-                .AddTile(TileID.WorkBenches)
+                .AddTile(TileID.MythrilAnvil)
                 .Register();
         }
     }

--- a/Content/Items/Weapons/Fractal/BrilliantFractal.cs
+++ b/Content/Items/Weapons/Fractal/BrilliantFractal.cs
@@ -17,8 +17,8 @@ namespace CalamityEntropy.Content.Items.Weapons.Fractal
     {
         public override void SetDefaults()
         {
-            Item.damage = 85;
-            Item.crit = 7;
+            Item.damage = 75;
+            Item.crit = 5;
             Item.DamageType = DamageClass.Melee;
             Item.width = 48;
             Item.height = 60;

--- a/Content/Items/Weapons/Fractal/VoidFractal.cs
+++ b/Content/Items/Weapons/Fractal/VoidFractal.cs
@@ -51,8 +51,8 @@ namespace CalamityEntropy.Content.Items.Weapons.Fractal
             if (player.altFunctionUse == 2)
             {
                 CEUtils.PlaySound("VoidAnticipation", 1, position);
-                player.AddBuff(BuffID.ChaosState, 5 * 60);
-                Projectile.NewProjectile(source, position, velocity * 4, ModContent.ProjectileType<VoidSlash>(), damage * 22, 0, player.whoAmI);
+                player.AddBuff(BuffID.ChaosState, 15 * 60);
+                Projectile.NewProjectile(source, position, velocity * 4, ModContent.ProjectileType<VoidSlash>(), damage * 30, 0, player.whoAmI);
                 return false;
             }
             int at = 2;

--- a/Content/Items/Weapons/VoidDevastator.cs
+++ b/Content/Items/Weapons/VoidDevastator.cs
@@ -35,7 +35,7 @@ namespace CalamityEntropy.Content.Items.Weapons
 
         public override void AddRecipes()
         {
-            CreateRecipe().AddIngredient(ModContent.ItemType<VoidBar>(), 12).AddIngredient(ModContent.ItemType<ArmoredShell>(), 8).AddIngredient(ModContent.ItemType<CoreofCalamity>(), 6).AddIngredient(ItemID.Celeb2, 1).AddTile(ModContent.TileType<CosmicAnvil>()).Register();
+            CreateRecipe().AddIngredient(ModContent.ItemType<VoidBar>(), 12).AddIngredient(ModContent.ItemType<ArmoredShell>(), 8).AddIngredient(ModContent.ItemType<CoreofCalamity>(), 1).AddIngredient(ItemID.Celeb2, 1).AddTile(ModContent.TileType<CosmicAnvil>()).Register();
         }
         public override bool RangedPrefix()
         {

--- a/Content/NPCs/LotteryMachine.cs
+++ b/Content/NPCs/LotteryMachine.cs
@@ -293,9 +293,9 @@ namespace CalamityEntropy.Content.NPCs
                 s1.Add(new RewardPoolItem(ModContent.ItemType<MurkyPaste>(), 4));
                 s1.Add(new RewardPoolItem(ModContent.ItemType<DubiousPlating>(), 4)); s1.Add(new RewardPoolItem(ModContent.ItemType<MysteriousCircuitry>(), 4));
                 s1.Add(new RewardPoolItem(ModContent.ItemType<StormlionMandible>(), 1)); s1.Add(new RewardPoolItem(ModContent.ItemType<StormjawStaff>(), 1));
-                s1.Add(new RewardPoolItem(ModContent.ItemType<BloodOrb>(), 20)); s1.Add(new RewardPoolItem(ItemID.Diamond, 5));
-                s1.Add(new RewardPoolItem(68, 8)); s1.Add(new RewardPoolItem(ModContent.ItemType<MurkyPaste>(), 10));
-                s1.Add(new RewardPoolItem(ModContent.ItemType<AncientBoneDust>(), 2)); s1.Add(new RewardPoolItem(ItemID.PoopBlock, 50));
+                s1.Add(new RewardPoolItem(ItemID.Diamond, 5));
+                s1.Add(new RewardPoolItem(68, 8)); 
+                s1.Add(new RewardPoolItem(ModContent.ItemType<AncientBoneDust>(), 2)); s1.Add(new RewardPoolItem(ItemID.PoopBlock, 10));
                 s1.Add(new RewardPoolItem(296, 1));
                 s1.Add(new RewardPoolItem(0, 1));
                 s1.Add(new RewardPoolItem(ItemID.Heart, 10));

--- a/Content/NPCs/LotteryMachine.cs
+++ b/Content/NPCs/LotteryMachine.cs
@@ -305,9 +305,9 @@ namespace CalamityEntropy.Content.NPCs
 
                 g1 = new RewardPool();
                 g1.Add(new RewardPoolItem(ModContent.ItemType<SulphuricScale>(), 1)); g1.Add(new RewardPoolItem(1320, 1));
-                g1.Add(new RewardPoolItem(ModContent.ItemType<DemonicBoneAsh>(), 2)); g1.Add(new RewardPoolItem(ModContent.ItemType<SuspiciousScrap>(), 1));
+                g1.Add(new RewardPoolItem(ModContent.ItemType<DemonicBoneAsh>(), 2)); 
                 g1.Add(new RewardPoolItem(ItemID.LifeCrystal, 4));
-                g1.Add(new RewardPoolItem(ModContent.ItemType<AshenStalactite>(), 1)); g1.Add(new RewardPoolItem(ModContent.ItemType<VoltaicJelly>(), 1));
+                g1.Add(new RewardPoolItem(ModContent.ItemType<AshenStalactite>(), 1)); 
                 g1.Add(new RewardPoolItem(ModContent.ItemType<RottenDogtooth>(), 1));
                 g1.Add(new RewardPoolItem(ModContent.ItemType<AncientBoneDust>(), 2)); s1.Add(new RewardPoolItem(ItemID.PoopBlock, 50));
                 g1.Add(new RewardPoolItem(0, 1));

--- a/Content/NPCs/LotteryMachine.cs
+++ b/Content/NPCs/LotteryMachine.cs
@@ -389,25 +389,15 @@ namespace CalamityEntropy.Content.NPCs
                 p3 = new RewardPool();
 
                 p3.Add(new RewardPoolItem(ModContent.ItemType<Necroplasm>(), 30));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<DarkPlasma>(), 3));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<UelibloomBar>(), 5));
                 p3.Add(new RewardPoolItem(ModContent.ItemType<AuricOre>(), 1));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<DivineGeode>(), 8));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<RuinousSoul>(), 3));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<TwistingNether>(), 3));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<ArmoredShell>(), 3));
                 p3.Add(new RewardPoolItem(ModContent.ItemType<CosmicWorm>(), 1));
                 p3.Add(new RewardPoolItem(ModContent.ItemType<SupremeHealingPotion>(), 10));
                 p3.Add(new RewardPoolItem(ModContent.ItemType<EidolicWail>(), 1));
                 p3.Add(new RewardPoolItem(ModContent.ItemType<PhosphorescentGauntlet>(), 1));
                 p3.Add(new RewardPoolItem(ModContent.ItemType<Murasama>(), 1));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<EmpyreanKnives>(), 1));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<AscendantSpiritEssence>(), 5));
                 p3.Add(new RewardPoolItem(ItemID.LastPrism, 1));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<CodebreakerBase>(), 1));
-
                 p3.Add(new RewardPoolItem(ModContent.ItemType<PristineFury>(), 1));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<Norfleet>(), 1));
+                p3.Add(new RewardPoolItem(ModContent.ItemType<Deathwind>(), 1));
                 p3.Add(new RewardPoolItem(ModContent.ItemType<PrisonOfPermafrost>(), 1));
                 p3.Add(new RewardPoolItem(ModContent.ItemType<AncientBoneDust>(), 2));
 
@@ -420,9 +410,7 @@ namespace CalamityEntropy.Content.NPCs
                 p4.Add(new RewardPoolItem(ModContent.ItemType<Sacrifice>(), 1));
                 p4.Add(new RewardPoolItem(ModContent.ItemType<YharonSoulFragment>(), 25));
                 p4.Add(new RewardPoolItem(ModContent.ItemType<AuricBar>(), 10));
-                p4.Add(new RewardPoolItem(ModContent.ItemType<ExoPrism>(), 55));
                 p4.Add(new RewardPoolItem(ItemID.Zenith, 1));
-                p4.Add(new RewardPoolItem(ModContent.ItemType<AncientBoneDust>(), 2));
 
                 #endregion
             }

--- a/Content/NPCs/LotteryMachine.cs
+++ b/Content/NPCs/LotteryMachine.cs
@@ -334,9 +334,7 @@ namespace CalamityEntropy.Content.NPCs
                 g2.Add(new RewardPoolItem(ModContent.ItemType<TitanHeart>(), 3));
                 g2.Add(new RewardPoolItem(ModContent.ItemType<UrsaSergeant>(), 1));
                 g2.Add(new RewardPoolItem(ModContent.ItemType<TrapperBulb>(), 5));
-                g2.Add(new RewardPoolItem(ModContent.ItemType<Lumenyl>(), 30));
-                g2.Add(new RewardPoolItem(ModContent.ItemType<LivingShard>(), 5));
-                g2.Add(new RewardPoolItem(ModContent.ItemType<SolarVeil>(), 10));
+                g2.Add(new RewardPoolItem(ModContent.ItemType<SolarVeil>(), 2));
                 g2.Add(new RewardPoolItem(ModContent.ItemType<AshesofCalamity>(), 1));
                 g2.Add(new RewardPoolItem(1508, 3));
                 g2.Add(new RewardPoolItem(391, 15));
@@ -353,16 +351,12 @@ namespace CalamityEntropy.Content.NPCs
                 p2.Add(new RewardPoolItem(3457, 10));
                 p2.Add(new RewardPoolItem(3458, 10));
                 p2.Add(new RewardPoolItem(3459, 10));
-                p2.Add(new RewardPoolItem(ModContent.ItemType<MeldBlob>(), 30));
-                p2.Add(new RewardPoolItem(ModContent.ItemType<PlagueCellCanister>(), 22));
-                p2.Add(new RewardPoolItem(ModContent.ItemType<UnholyEssence>(), 2));
-                p2.Add(new RewardPoolItem(ModContent.ItemType<EffulgentFeather>(), 3));
-                p2.Add(new RewardPoolItem(ModContent.ItemType<StarbusterCore>(), 1));
+                p2.Add(new RewardPoolItem(ModContent.ItemType<MeldBlob>(), 1));
+                p2.Add(new RewardPoolItem(ModContent.ItemType<EffulgentFeather>(), 1));
                 p2.Add(new RewardPoolItem(ModContent.ItemType<TheFirstShadowflame>(), 1));
-                p2.Add(new RewardPoolItem(ModContent.ItemType<EtherealExtorter>(), 1));
                 p2.Add(new RewardPoolItem(ModContent.ItemType<Baroclaw>(), 1));
                 p2.Add(new RewardPoolItem(ModContent.ItemType<InfectedJewel>(), 1));
-                p2.Add(new RewardPoolItem(ModContent.ItemType<AstralBar>(), 2));
+                p2.Add(new RewardPoolItem(ModContent.ItemType<CryonicBar>(), 3));
                 p2.Add(new RewardPoolItem(ModContent.ItemType<YharimsStimulants>(), 16));
                 p2.Add(new RewardPoolItem(ModContent.ItemType<TheCamper>(), 1));
                 p2.Add(new RewardPoolItem(ModContent.ItemType<SHPC>(), 1));
@@ -381,7 +375,6 @@ namespace CalamityEntropy.Content.NPCs
                 p3.Add(new RewardPoolItem(ModContent.ItemType<AuguroftheElements>(), 1));
                 p3.Add(new RewardPoolItem(ModContent.ItemType<ElementalAxe>(), 1));
                 p3.Add(new RewardPoolItem(ModContent.ItemType<SanctifiedSpark>(), 1));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<SealedSingularity>(), 1));
                 p3.Add(new RewardPoolItem(ModContent.ItemType<ElementalDisk>(), 1));
                 p3.Add(new RewardPoolItem(ModContent.ItemType<AbyssalDivingSuit>(), 1));
                 p3.Add(new RewardPoolItem(ModContent.ItemType<MirrorBlade>(), 1));
@@ -391,9 +384,8 @@ namespace CalamityEntropy.Content.NPCs
                 p3.Add(new RewardPoolItem(ModContent.ItemType<PlanetaryAnnihilation>(), 1));
                 p3.Add(new RewardPoolItem(ModContent.ItemType<TwistingNether>(), 1));
                 p3.Add(new RewardPoolItem(ModContent.ItemType<ArmoredShell>(), 1));
-                p2.Add(new RewardPoolItem(ModContent.ItemType<HadalMantle>(), 1));
-                p2.Add(new RewardPoolItem(ModContent.ItemType<OccultSkullCrown>(), 1));
-                p2.Add(new RewardPoolItem(ModContent.ItemType<AncientBoneDust>(), 2));
+                p3.Add(new RewardPoolItem(ModContent.ItemType<OccultSkullCrown>(), 1));
+                p3.Add(new RewardPoolItem(ModContent.ItemType<AncientBoneDust>(), 2));
                 p3 = new RewardPool();
 
                 p3.Add(new RewardPoolItem(ModContent.ItemType<Necroplasm>(), 30));

--- a/Localization/en-US_Mods.CalamityEntropy.hjson
+++ b/Localization/en-US_Mods.CalamityEntropy.hjson
@@ -3377,20 +3377,20 @@ ArmorPrefixHardDescription: +10% defense
 ArmorPrefixLightName: Light
 ArmorPrefixLightDescription:
 	'''
-	+10% Move Speed
-	+10% Wing Speed
+	+3% Move Speed
+	+5% Wing Speed
 	'''
 ArmorPrefixBrokenName: Broken
 ArmorPrefixBrokenDescription: -20% Defense
 ArmorPrefixGodForgedName: God Forged
 ArmorPrefixGodForgedDescription:
 	'''
-	+15%Defense
-	+2% Damage Reduce
-	+4% Damage
+	+8%Defense
+	+1% Damage Reduce
+	+3% Damage
 	'''
 ArmorPrefixGuardedName: Guarded
-ArmorPrefixGuardedDescription: +20% Defense
+ArmorPrefixGuardedDescription: +15% Defense
 ArmorPrefixHeavyName: Heavy
 ArmorPrefixHeavyDescription: -10% Move Speed
 ArmorPrefixResilientName: Resilient
@@ -3406,34 +3406,33 @@ ArmorPrefixWaterWalkerDescription: Enable you to walk on the water surface
 ArmorPrefixMiracleName: Miracle
 ArmorPrefixMiracleDescription:
 	'''
-	+10% Defense
-	+1% Damage Reduce
+	+5% Defense
 	+20% Light
-	+4% Damage
+	+2% Damage
 	'''
 ArmorPrefixGreatName: Great
 ArmorPrefixGreatDescription:
 	'''
-	+12% Defense
-	+4% Damage
+	+8% Defense
+	+2% Damage
 	'''
 ArmorPrefixMassiveName: Massive
 ArmorPrefixMassiveDescription:
 	'''
-	+35% Defense
-	-15% Move Speed
+	+25% Defense
+	-30% Move Speed
 	'''
 ArmorPrefixDestinedGreatnessName: Destined Greatness
 ArmorPrefixDestinedGreatnessDescription:
 	'''
-	+4% Crit
-	+10% Defense
+	+2% Crit
+	+5% Defense
 	+1 Luck
 	'''
 ArmorPrefixRegenName: Regen
 ArmorPrefixRegenDescription: +1/s Life Regen
 ArmorPrefixVoidTouchedName: Void Touched
-ArmorPrefixVoidTouchedDescription: +0.3 Void Touch
+ArmorPrefixVoidTouchedDescription: +0.2 Void Touch
 ArmorPrefixBiochemistryName: Biochemistry
 ArmorPrefixBiochemistryDescription: +15% Debuff immunity probability
 ArmorPrefixVoidName: Void
@@ -3446,33 +3445,37 @@ ArmorPrefixVoidDescription:
 ArmorPrefixRecklessName: Reckless
 ArmorPrefixRecklessDescription:
 	'''
-	+7% Damage
-	-40% Defense
+	+5% Damage
+	-50% Defense
 	'''
 ArmorPrefixSacrificalName: Sacrifical
 ArmorPrefixSacrificalDescription:
 	'''
-	+16% Damage
-	-70% Defense
+	+10% Damage
+	-99% Defense
 	'''
 ArmorPrefixSilenceName: Silence
-ArmorPrefixSilenceDescription: +1% Max Stealth
+ArmorPrefixSilenceDescription: +2% Max Stealth
 ArmorPrefixMagicalName: Magical
 ArmorPrefixMagicalDescription:
 	'''
-	+6 Max Mana
-	-10% Mana Cost
-	+10% Enhanced Mana
+	+10 Max Mana
+	-5% Mana Cost
+	+6% Enhanced Mana
 	'''
 ArmorPrefixEvokerName: Evoker
-ArmorPrefixEvokerDescription: +1 Max Minion
+ArmorPrefixEvokerDescription: 
+	'''
+	+1 Max Minion
+	-15% Damage
+	'''
 ArmorPrefixEndName: End
 ArmorPrefixEndDescription:
 	'''
 	+12% Defense
-	+10% Damage
+	+5% Damage
 	+20% Knockback
-	+6% Crit
+	+4% Crit
 	+100% Reverse injury
 	+0.1 Void Touch
 	'''
@@ -3480,13 +3483,13 @@ ArmorPrefixWizardName: Wizard
 ArmorPrefixWizardDescription:
 	'''
 	+1 Max Minions
-	+2% Summon Damage
+	-10% Damage
 	'''
 ArmorPrefixLastStandName: Last Stand
 ArmorPrefixLastStandDescription:
 	'''
-	+30% Defense
-	+5% Damage Reduce
+	+15% Defense
+	+2% Damage Reduce
 	'''
 ArmorPrefixHeatDeathName: Heat Death
 ArmorPrefixHeatDeathDescription:

--- a/Localization/zh-Hans_Mods.CalamityEntropy.hjson
+++ b/Localization/zh-Hans_Mods.CalamityEntropy.hjson
@@ -3538,20 +3538,20 @@ ArmorPrefixHardDescription: +10% 防御
 ArmorPrefixLightName: 轻便
 ArmorPrefixLightDescription:
 	'''
-	+10% 移动速度
-	+10% 飞行速度
+	+3% 移动速度
+	+5% 飞行速度
 	'''
 ArmorPrefixBrokenName: 破损
 ArmorPrefixBrokenDescription: -20% 防御
 ArmorPrefixGodForgedName: 神铸
 ArmorPrefixGodForgedDescription:
 	'''
-	+15% 防御
-	+2% 伤害减免
-	+4% 伤害
+	+8% 防御
+	+1% 伤害减免
+	+3% 伤害
 	'''
 ArmorPrefixGuardedName: 守护
-ArmorPrefixGuardedDescription: +20% 防御
+ArmorPrefixGuardedDescription: +15% 防御
 ArmorPrefixHeavyName: 沉重
 ArmorPrefixHeavyDescription: -10% 移动速度
 ArmorPrefixResilientName: 弹力
@@ -3567,34 +3567,33 @@ ArmorPrefixWaterWalkerDescription: 使你能够在水面上行走
 ArmorPrefixMiracleName: 奇迹
 ArmorPrefixMiracleDescription:
 	'''
-	+10% 防御
-	+1% 伤害减免
+	+5% 防御
 	+20% 盔甲光照
-	+4% 伤害
+	+2% 伤害
 	'''
 ArmorPrefixGreatName: 杰出
 ArmorPrefixGreatDescription:
 	'''
-	+12% 防御
-	+4% 伤害
+	+8% 防御
+	+2% 伤害
 	'''
 ArmorPrefixMassiveName: 厚重
 ArmorPrefixMassiveDescription:
 	'''
-	+35% 防御
-	-15% 移动速度
+	+25% 防御
+	-30% 移动速度
 	'''
 ArmorPrefixDestinedGreatnessName: 注定伟大
 ArmorPrefixDestinedGreatnessDescription:
 	'''
-	+4% 暴击率
-	+10% 防御
+	+2% 暴击率
+	+5% 防御
 	+1 幸运
 	'''
 ArmorPrefixRegenName: 再生
 ArmorPrefixRegenDescription: +1/s 每秒生命再生
 ArmorPrefixVoidTouchedName: 虚空之触
-ArmorPrefixVoidTouchedDescription: +0.3 虚空之触
+ArmorPrefixVoidTouchedDescription: +0.2 虚空之触
 ArmorPrefixBiochemistryName: 生化
 ArmorPrefixBiochemistryDescription: +15% 减益免疫概率
 ArmorPrefixVoidName: 虚空
@@ -3607,33 +3606,37 @@ ArmorPrefixVoidDescription:
 ArmorPrefixRecklessName: 鲁莽
 ArmorPrefixRecklessDescription:
 	'''
-	+7% 伤害
-	-40% 防御
+	+5% 伤害
+	-50% 防御
 	'''
 ArmorPrefixSacrificalName: 牺牲
 ArmorPrefixSacrificalDescription:
 	'''
-	+16% 伤害
-	-70% 防御
+	+10% 伤害
+	-99% 防御
 	'''
 ArmorPrefixSilenceName: 寂静
-ArmorPrefixSilenceDescription: +1 最大潜行值
+ArmorPrefixSilenceDescription: +2 最大潜行值
 ArmorPrefixMagicalName: 注魔
 ArmorPrefixMagicalDescription:
 	'''
-	+6 最大魔力值
-	-10% 魔力消耗
-	+10% 强化魔力
+	+10 最大魔力值
+	-5% 魔力消耗
+	+6% 强化魔力
 	'''
 ArmorPrefixEvokerName: 唤灵
-ArmorPrefixEvokerDescription: +1 召唤栏
+ArmorPrefixEvokerDescription: 
+	'''
+	+1 召唤栏
+	-15% 伤害
+	'''
 ArmorPrefixEndName: 末日
 ArmorPrefixEndDescription:
 	'''
 	+12% 防御
-	+10% 伤害
+	+5% 伤害
 	+20% 击退
-	+6% 暴击
+	+4% 暴击
 	+100% 接触伤害反伤
 	+0.1 虚空之触
 	'''
@@ -3641,13 +3644,13 @@ ArmorPrefixWizardName: 巫祝
 ArmorPrefixWizardDescription:
 	'''
 	+1 召唤栏
-	+2% 召唤伤害
+	-10% 伤害
 	'''
 ArmorPrefixLastStandName: 屹立不倒
 ArmorPrefixLastStandDescription:
 	'''
-	+30% 防御
-	+5% 伤害减免
+	+15% 防御
+	+2% 伤害减免
 	增加一次复活机会
 	该复活不可叠加
 	'''


### PR DESCRIPTION
1.虚泯湮灭者:材料中的灾劫核心数目降低至1
2.虚空分形:右键冷却延长至15秒，伤害倍率提升至3000%（防止右键成为传送器）
3.光辉分形:面板降低至75，暴击降低至5（对照环境刃丛林调谐）
4.把先知和星光蛾子的召唤物制作站换成了秘银砧（建议按照bosslist里的顺序调整蛾子和先知在br里的出场顺序）
5.修改了抽奖机奖池，去除了某些重复的，明显影响所处时期的物品

6.盔甲词条系列更改:（这些改动旨在让词条与旧版本的成长系统更加贴近，作为附加辅助手段而非常规饰品取代物）
注定伟大防御提升降低到5%，暴击率降低至2%
末日暴击降低至4%，伤害加成降低至5%，配方里加入湮灭余烬
唤灵会同时降低玩家15%的伤害（灾厄召唤兽很强，要适当限制）
神铸防御加成降低至8%，伤害加成降低至3%，免伤加成降低至1%
杰出防御加成降低至8%，伤害加成降低至2%
守护，防御加成降低至15%
屹立不倒，免伤降低至2%，防御加成降低至15%
注魔的强化魔力加成降低至6%，魔力减耗降低至5%，常规魔力加成提升至10
厚重的防御加成降低至25%，移速惩罚提升至30%
奇迹的免伤去除，伤害加成降低至2%，防御加成降低至5%
鲁莽，伤害加成降低至5%，防御惩罚提升至50%
牺牲，伤害加成降低至10%，防御惩罚提升至99%
寂静潜伏值加成提升至2
虚空之触的加成降低至0.2
巫祝现在会降低10%伤害
轻便，移速加成和翅膀加成降低至3%与5%