### PR TITLE
盗贼投矛手感优化

### DIFF
--- a/Content/Items/DivineIntervention.cs
+++ b/Content/Items/DivineIntervention.cs
@@ -36,8 +36,8 @@ namespace CalamityEntropy.Content.Items
         }
         public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
         {
-            player.AddBuff(ModContent.BuffType<DivingShieldCooldown>(), 3600, true, false);
-            player.AddCooldown(DivingCd.ID, 3600);
+            player.AddBuff(ModContent.BuffType<DivingShieldCooldown>(), 18000, true, false);
+            player.AddCooldown(DivingCd.ID, 18000);
             return true;
         }
 

--- a/Content/Items/Weapons/AbyssalPiercer.cs
+++ b/Content/Items/Weapons/AbyssalPiercer.cs
@@ -30,7 +30,7 @@ namespace CalamityEntropy.Content.Items.Weapons
             Item.value = CalamityGlobalItem.RarityPinkBuyPrice;
             Item.rare = ItemRarityID.Pink;
             Item.shoot = ModContent.ProjectileType<AbyssalPiercerThrow>();
-            Item.shootSpeed = 36f;
+            Item.shootSpeed = 40f;
             Item.DamageType = CEUtils.RogueDC;
         }
 

--- a/Content/Items/Weapons/Aquashard.cs
+++ b/Content/Items/Weapons/Aquashard.cs
@@ -23,7 +23,6 @@ namespace CalamityEntropy.Content.Items.Weapons
             Item.noUseGraphic = true;
             Item.useAnimation = Item.useTime = 30;
             Item.useStyle = ItemUseStyleID.Swing;
-            Item.ArmorPenetration = 86;
             Item.knockBack = 1f;
             Item.UseSound = null;
             Item.autoReuse = true;
@@ -31,7 +30,7 @@ namespace CalamityEntropy.Content.Items.Weapons
             Item.value = CalamityGlobalItem.RarityOrangeBuyPrice;
             Item.rare = ItemRarityID.Orange;
             Item.shoot = ModContent.ProjectileType<AquashardThrow>();
-            Item.shootSpeed = 36f;
+            Item.shootSpeed = 40f;
             Item.DamageType = CEUtils.RogueDC;
         }
 

--- a/Content/Items/Weapons/ArbitratorII.cs
+++ b/Content/Items/Weapons/ArbitratorII.cs
@@ -16,13 +16,11 @@ namespace CalamityEntropy.Content.Items.Weapons
         {
             Item.width = 62;
             Item.height = 62;
-            Item.damage = 250;
-            Item.ArmorPenetration = 12;
+            Item.damage = 165;
             Item.noMelee = true;
             Item.noUseGraphic = true;
-            Item.useAnimation = Item.useTime = 30;
+            Item.useAnimation = Item.useTime = 40;
             Item.useStyle = ItemUseStyleID.Swing;
-            Item.ArmorPenetration = 86;
             Item.knockBack = 1f;
             Item.UseSound = null;
             Item.autoReuse = true;
@@ -30,7 +28,7 @@ namespace CalamityEntropy.Content.Items.Weapons
             Item.value = CalamityGlobalItem.RarityPinkBuyPrice;
             Item.rare = ItemRarityID.Pink;
             Item.shoot = ModContent.ProjectileType<ArbitratorIIThrow>();
-            Item.shootSpeed = 36f;
+            Item.shootSpeed = 50f;
             Item.DamageType = CEUtils.RogueDC;
         }
 

--- a/Content/Items/Weapons/ArbitratorII.cs
+++ b/Content/Items/Weapons/ArbitratorII.cs
@@ -19,7 +19,7 @@ namespace CalamityEntropy.Content.Items.Weapons
             Item.damage = 165;
             Item.noMelee = true;
             Item.noUseGraphic = true;
-            Item.useAnimation = Item.useTime = 40;
+            Item.useAnimation = Item.useTime = 26;
             Item.useStyle = ItemUseStyleID.Swing;
             Item.knockBack = 1f;
             Item.UseSound = null;

--- a/Content/Items/Weapons/AzureOfFirmament.cs
+++ b/Content/Items/Weapons/AzureOfFirmament.cs
@@ -17,12 +17,11 @@ namespace CalamityEntropy.Content.Items.Weapons
             Item.width = 42;
             Item.height = 42;
             Item.damage = 40;
-            Item.ArmorPenetration = 8;
+            Item.ArmorPenetration = 10;
             Item.noMelee = true;
             Item.noUseGraphic = true;
             Item.useAnimation = Item.useTime = 24;
             Item.useStyle = ItemUseStyleID.Swing;
-            Item.ArmorPenetration = 86;
             Item.knockBack = 1f;
             Item.UseSound = null;
             Item.autoReuse = true;
@@ -30,7 +29,7 @@ namespace CalamityEntropy.Content.Items.Weapons
             Item.value = CalamityGlobalItem.RarityOrangeBuyPrice;
             Item.rare = ItemRarityID.Orange;
             Item.shoot = ModContent.ProjectileType<AzureOfFirmamentThrow>();
-            Item.shootSpeed = 32f;
+            Item.shootSpeed = 50f;
             Item.DamageType = CEUtils.RogueDC;
         }
 

--- a/Content/Items/Weapons/ShadewindLance.cs
+++ b/Content/Items/Weapons/ShadewindLance.cs
@@ -19,12 +19,11 @@ namespace CalamityEntropy.Content.Items.Weapons
             Item.width = 36;
             Item.height = 34;
             Item.damage = 3000;
-            Item.ArmorPenetration = 56;
+            Item.ArmorPenetration = 50;
             Item.noMelee = true;
             Item.noUseGraphic = true;
             Item.useAnimation = Item.useTime = 30;
             Item.useStyle = ItemUseStyleID.Swing;
-            Item.ArmorPenetration = 86;
             Item.knockBack = 1f;
             Item.UseSound = SoundID.Item1;
             Item.autoReuse = true;

--- a/Content/NPCs/LotteryMachine.cs
+++ b/Content/NPCs/LotteryMachine.cs
@@ -391,24 +391,24 @@ namespace CalamityEntropy.Content.NPCs
                 p3.Add(new RewardPoolItem(ModContent.ItemType<Necroplasm>(), 30));
                 p3.Add(new RewardPoolItem(ModContent.ItemType<AuricOre>(), 1));
                 p3.Add(new RewardPoolItem(ModContent.ItemType<CosmicWorm>(), 1));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<SupremeHealingPotion>(), 10));
+                p3.Add(new RewardPoolItem(ModContent.ItemType<SupremeHealingPotion>(), 3));
                 p3.Add(new RewardPoolItem(ModContent.ItemType<EidolicWail>(), 1));
                 p3.Add(new RewardPoolItem(ModContent.ItemType<PhosphorescentGauntlet>(), 1));
                 p3.Add(new RewardPoolItem(ModContent.ItemType<Murasama>(), 1));
                 p3.Add(new RewardPoolItem(ItemID.LastPrism, 1));
                 p3.Add(new RewardPoolItem(ModContent.ItemType<PristineFury>(), 1));
                 p3.Add(new RewardPoolItem(ModContent.ItemType<Deathwind>(), 1));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<PrisonOfPermafrost>(), 1));
                 p3.Add(new RewardPoolItem(ModContent.ItemType<AncientBoneDust>(), 2));
 
                 p4 = new RewardPool();
+                p4.Add(new RewardPoolItem(ModContent.ItemType<PrisonOfPermafrost>(), 1));
                 p4.Add(new RewardPoolItem(ModContent.ItemType<CodebreakerBase>(), 1));
                 p4.Add(new RewardPoolItem(ModContent.ItemType<YharimsCrystal>(), 1));
                 p4.Add(new RewardPoolItem(ModContent.ItemType<AscendantSpiritEssence>(), 15));
                 p4.Add(new RewardPoolItem(ModContent.ItemType<AuricOre>(), 100));
                 p4.Add(new RewardPoolItem(ModContent.ItemType<Vehemence>(), 1));
                 p4.Add(new RewardPoolItem(ModContent.ItemType<Sacrifice>(), 1));
-                p4.Add(new RewardPoolItem(ModContent.ItemType<YharonSoulFragment>(), 25));
+                p4.Add(new RewardPoolItem(ModContent.ItemType<YharonSoulFragment>(), 15));
                 p4.Add(new RewardPoolItem(ModContent.ItemType<AuricBar>(), 10));
                 p4.Add(new RewardPoolItem(ItemID.Zenith, 1));
 


### PR DESCRIPTION
1.盗贼投矛提升射弹速度，同时去除了一部分重复的穿甲（由于这些矛有起手动作，弹速慢会导致容易打空）
2.仲裁者2的面板降低至165，使用时间缩短
3.神圣干预由于其强大的效果，大幅加长冷却时间，达到类似于林海复活那样一局只能用一次的效果
4.抽奖机把樊寒塞到了龙后，降低了一些稀有物品的抽取改了