### PR TITLE
部分虚渺武器强化

### DIFF
--- a/Content/Items/Books/AshTranscript.cs
+++ b/Content/Items/Books/AshTranscript.cs
@@ -16,10 +16,10 @@ namespace CalamityEntropy.Content.Items.Books
         public override void SetDefaults()
         {
             base.SetDefaults();
-            Item.damage = 130;
+            Item.damage = 160;
             Item.useAnimation = Item.useTime = 27;
             Item.crit = 10;
-            Item.mana = 22;
+            Item.mana = 12;
             Item.rare = ModContent.RarityType<Turquoise>();
             Item.value = CalamityGlobalItem.RarityTurquoiseBuyPrice;
         }

--- a/Content/Items/Books/ControlTerminal.cs
+++ b/Content/Items/Books/ControlTerminal.cs
@@ -27,7 +27,7 @@ namespace CalamityEntropy.Content.Items.Books
         public override void SetDefaults()
         {
             base.SetDefaults();
-            Item.damage = 100;
+            Item.damage = 150;
             Item.useAnimation = Item.useTime = 100;
             Item.crit = 10;
             Item.mana = 36;
@@ -41,7 +41,7 @@ namespace CalamityEntropy.Content.Items.Books
 
         public override void AddRecipes()
         {
-            CreateRecipe().AddIngredient<VoidOde>()
+            CreateRecipe().AddIngredient<ProphecyMasterpiece>()
                 .AddIngredient<ExoPrism>(5)
                 .AddTile<DraedonsForge>()
                 .Register();

--- a/Content/Items/Books/RedemptionBible.cs
+++ b/Content/Items/Books/RedemptionBible.cs
@@ -27,8 +27,8 @@ namespace CalamityEntropy.Content.Items.Books
         public override void AddRecipes()
         {
             CreateRecipe().AddIngredient<UpdraftTome>()
-                .AddIngredient(ItemID.HallowedBar, 6)
-                .AddIngredient(ItemID.SoulofLight, 4)
+                .AddIngredient(ItemID.UnicornHorn, 6)
+                .AddIngredient(ItemID.SoulofLight, 10)
                 .AddTile(TileID.MythrilAnvil)
                 .Register();
         }

--- a/Content/Items/Books/TabooVolume.cs
+++ b/Content/Items/Books/TabooVolume.cs
@@ -33,7 +33,7 @@ namespace CalamityEntropy.Content.Items.Books
         public override void AddRecipes()
         {
 
-            CreateRecipe().AddIngredient<VoidOde>()
+            CreateRecipe().AddIngredient<BurntLostClassics>()
                 .AddIngredient<Heresy>()
                 .AddIngredient<AshesofAnnihilation>(6)
                 .AddTile<DraedonsForge>()

--- a/Content/Items/Weapons/Fractal/AbyssFractal.cs
+++ b/Content/Items/Weapons/Fractal/AbyssFractal.cs
@@ -19,12 +19,12 @@ namespace CalamityEntropy.Content.Items.Weapons.Fractal
     {
         public override void SetDefaults()
         {
-            Item.damage = 95;
+            Item.damage = 90;
             Item.crit = 7;
             Item.DamageType = DamageClass.Melee;
             Item.width = 60;
             Item.height = 40;
-            Item.useTime = Item.useAnimation = 30;
+            Item.useTime = Item.useAnimation = 24;
             Item.useStyle = ItemUseStyleID.Shoot;
             Item.knockBack = 2;
             Item.value = CalamityGlobalItem.RarityYellowBuyPrice;

--- a/Content/Items/Weapons/Fractal/StarlitFractal.cs
+++ b/Content/Items/Weapons/Fractal/StarlitFractal.cs
@@ -20,7 +20,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Fractal
     {
         public override void SetDefaults()
         {
-            Item.damage = 130;
+            Item.damage = 140;
             Item.crit = 7;
             Item.DamageType = DamageClass.Melee;
             Item.width = 48;

--- a/Content/Items/Weapons/LightWisper.cs
+++ b/Content/Items/Weapons/LightWisper.cs
@@ -16,7 +16,7 @@ namespace CalamityEntropy.Content.Items.Weapons
         {
             Item.width = 98;
             Item.height = 46;
-            Item.damage = 315;
+            Item.damage = 340;
             Item.DamageType = DamageClass.Ranged;
             Item.useTime = 3;
             Item.useAnimation = 18;

--- a/Content/Items/Weapons/VoidDevastator.cs
+++ b/Content/Items/Weapons/VoidDevastator.cs
@@ -20,9 +20,9 @@ namespace CalamityEntropy.Content.Items.Weapons
             Item.DefaultToRangedWeapon(ProjectileID.RocketI, AmmoID.Rocket, singleShotTime: 20, shotVelocity: 28, hasAutoReuse: true);
             Item.width = 152;
             Item.height = 48;
-            Item.damage = 600;
+            Item.damage = 700;
             Item.knockBack = 4f;
-            Item.crit = 15;
+            Item.crit = 5;
             Item.UseSound = SoundID.Item11;
             Item.value = Item.buyPrice(gold: 80);
             Item.rare = ItemRarityID.Orange;

--- a/Content/Items/Weapons/VoidPathology.cs
+++ b/Content/Items/Weapons/VoidPathology.cs
@@ -17,7 +17,7 @@ namespace CalamityEntropy.Content.Items.Weapons
         {
             Item.width = 104;
             Item.height = 104;
-            Item.damage = 180;
+            Item.damage = 200;
             Item.noMelee = true;
             Item.useAnimation = Item.useTime = 26;
             Item.useStyle = ItemUseStyleID.Shoot;
@@ -28,7 +28,7 @@ namespace CalamityEntropy.Content.Items.Weapons
             Item.rare = ModContent.RarityType<Violet>();
             Item.shoot = ModContent.ProjectileType<NihilityVirus>();
             Item.shootSpeed = 16f;
-            Item.mana = 12;
+            Item.mana = 6;
             Item.DamageType = DamageClass.Magic;
             Item.channel = true;
             Item.useTurn = false;

--- a/Content/Projectiles/LightWisperFlame.cs
+++ b/Content/Projectiles/LightWisperFlame.cs
@@ -29,12 +29,12 @@ namespace CalamityEntropy.Content.Projectiles
             base.Projectile.ignoreWater = true;
             base.Projectile.tileCollide = false;
             base.Projectile.DamageType = DamageClass.Ranged;
-            base.Projectile.penetrate = 16;
+            base.Projectile.penetrate = 20;
             base.Projectile.MaxUpdates = 4;
             base.Projectile.timeLeft = Lifetime;
             base.Projectile.usesIDStaticNPCImmunity = true;
             base.Projectile.idStaticNPCHitCooldown = 3;
-            Projectile.ArmorPenetration = 14;
+            Projectile.ArmorPenetration = 50;
         }
 
         public override void AI()
@@ -103,11 +103,6 @@ namespace CalamityEntropy.Content.Projectiles
 
         public override void ModifyHitNPC(NPC target, ref NPC.HitModifiers modifiers)
         {
-            if (base.Projectile.numHits > 0)
-            {
-                base.Projectile.damage = (int)((float)base.Projectile.damage * 0.75f);
-            }
-
             if (base.Projectile.damage < 1)
             {
                 base.Projectile.damage = 1;

--- a/Content/Projectiles/LightWisperFlame.cs
+++ b/Content/Projectiles/LightWisperFlame.cs
@@ -34,7 +34,7 @@ namespace CalamityEntropy.Content.Projectiles
             base.Projectile.timeLeft = Lifetime;
             base.Projectile.usesIDStaticNPCImmunity = true;
             base.Projectile.idStaticNPCHitCooldown = 3;
-            Projectile.ArmorPenetration = 50;
+            Projectile.ArmorPenetration = 20;
         }
 
         public override void AI()

--- a/Content/Projectiles/WindOfUndertakerProjectile.cs
+++ b/Content/Projectiles/WindOfUndertakerProjectile.cs
@@ -2,6 +2,8 @@
 using CalamityEntropy.Content.Projectiles.Cruiser;
 using Microsoft.Xna.Framework.Graphics;
 using System;
+using CalamityMod;
+using CalamityMod.Buffs.StatDebuffs;
 using System.Collections.Generic;
 using Terraria;
 using Terraria.Audio;
@@ -76,6 +78,7 @@ namespace CalamityEntropy.Content.Projectiles
         public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
         {
             target.AddBuff(ModContent.BuffType<CruiserWhipDebuff>(), 240);
+            target.AddBuff(ModContent.BuffType<MarkedforDeath>(), 150);
             Main.player[Projectile.owner].MinionAttackTargetNPC = target.whoAmI;
             Projectile.damage = (int)(Projectile.damage * 0.9f);
 


### PR DESCRIPTION
1.渺光，面板提升至340，去除穿透衰减，火焰穿甲提升至20，穿透数目提升至20
2.虚泯湮灭者，基础暴击率下降至5，面板提升至700
3.唤死之风，鞭子击打可以给目标施加150帧的死亡标记减益