### PR TITLE
新版本阿萨辐勒武器调整与水晶球强化

### DIFF
--- a/Content/Items/Weapons/AzafureFurnace.cs
+++ b/Content/Items/Weapons/AzafureFurnace.cs
@@ -13,7 +13,7 @@ namespace CalamityEntropy.Content.Items.Weapons
         {
             Item.width = 24;
             Item.height = 24;
-            Item.damage = 90;
+            Item.damage = 50;
             Item.DamageType = DamageClass.Magic;
             Item.useTime = 3;
             Item.useAnimation = 3;
@@ -25,12 +25,12 @@ namespace CalamityEntropy.Content.Items.Weapons
             Item.rare = ItemRarityID.Pink;
             Item.UseSound = null;
             Item.autoReuse = false;
-            Item.shootSpeed = 22f;
+            Item.shootSpeed = 25f;
             Item.channel = true;
             Item.noUseGraphic = true;
             var modItem = Item.Calamity();
             modItem.UsesCharge = true;
-            Item.mana = 10;
+            Item.mana = 15;
             modItem.MaxCharge = 200f;
             modItem.ChargePerUse = 0.08f;
         }
@@ -40,7 +40,7 @@ namespace CalamityEntropy.Content.Items.Weapons
             CreateRecipe().
                 AddIngredient(ModContent.ItemType<OverloadFurnace>()).
                 AddIngredient(ModContent.ItemType<HellIndustrialComponents>(), 4).
-                AddIngredient(ItemID.SoulofLight, 2).
+                AddIngredient(ItemID.SoulofNight, 10).
                 AddTile(TileID.MythrilAnvil).
                 Register();
         }

--- a/Content/Items/Weapons/AzafurePulseWand.cs
+++ b/Content/Items/Weapons/AzafurePulseWand.cs
@@ -21,7 +21,7 @@ namespace CalamityEntropy.Content.Items.Weapons
         {
             Item.width = 24;
             Item.height = 24;
-            Item.damage = 60;
+            Item.damage = 80;
             Item.DamageType = DamageClass.Magic;
             Item.useTime = 36;
             Item.useAnimation = 36;
@@ -36,7 +36,7 @@ namespace CalamityEntropy.Content.Items.Weapons
             Item.shootSpeed = 22f;
             Item.channel = true;
             Item.noUseGraphic = true;
-            Item.mana = 14;
+            Item.mana = 12;
         }
 
         public override void AddRecipes()

--- a/Content/Items/Weapons/CrystalBalls/EyeOfOtherside.cs
+++ b/Content/Items/Weapons/CrystalBalls/EyeOfOtherside.cs
@@ -27,14 +27,14 @@ namespace CalamityEntropy.Content.Items.Weapons.CrystalBalls
             Item.rare = ModContent.RarityType<PureGreen>();
             Item.shoot = ModContent.ProjectileType<EyeOfOthersideHoldout>();
             Item.shootSpeed = 16f;
-            Item.mana = 5;
+            Item.mana = 3;
             Item.DamageType = DamageClass.Magic;
         }
         public override void AddRecipes()
         {
             CreateRecipe()
-                .AddIngredient(ModContent.ItemType<Necroplasm>(), 5)
-                .AddIngredient(ModContent.ItemType<RuinousSoul>(), 1)
+                .AddIngredient(ModContent.ItemType<Necroplasm>(), 15)
+                .AddIngredient(ModContent.ItemType<RuinousSoul>(), 5)
                 .AddIngredient(ItemID.CrystalBall, 1)
                 .AddTile(TileID.LunarCraftingStation)
                 .Register();

--- a/Content/Items/Weapons/CrystalBalls/GravityGaze.cs
+++ b/Content/Items/Weapons/CrystalBalls/GravityGaze.cs
@@ -25,8 +25,8 @@ namespace CalamityEntropy.Content.Items.Weapons.CrystalBalls
             Item.value = CalamityGlobalItem.RarityOrangeBuyPrice;
             Item.rare = ItemRarityID.Orange;
             Item.shoot = ModContent.ProjectileType<GravityGazeHoldout>();
-            Item.shootSpeed = 16f;
-            Item.mana = 10;
+            Item.shootSpeed = 22f;
+            Item.mana = 3;
             Item.DamageType = DamageClass.Magic;
         }
         public override void AddRecipes()

--- a/Content/Items/Weapons/CrystalBalls/OverloadLunar.cs
+++ b/Content/Items/Weapons/CrystalBalls/OverloadLunar.cs
@@ -13,7 +13,7 @@ namespace CalamityEntropy.Content.Items.Weapons.CrystalBalls
         {
             Item.width = 44;
             Item.height = 44;
-            Item.damage = 80;
+            Item.damage = 85;
             Item.noMelee = true;
             Item.noUseGraphic = true;
             Item.useAnimation = Item.useTime = 20;

--- a/Content/Items/Weapons/CrystalBalls/OverloadLunar.cs
+++ b/Content/Items/Weapons/CrystalBalls/OverloadLunar.cs
@@ -13,7 +13,7 @@ namespace CalamityEntropy.Content.Items.Weapons.CrystalBalls
         {
             Item.width = 44;
             Item.height = 44;
-            Item.damage = 78;
+            Item.damage = 80;
             Item.noMelee = true;
             Item.noUseGraphic = true;
             Item.useAnimation = Item.useTime = 20;
@@ -26,7 +26,7 @@ namespace CalamityEntropy.Content.Items.Weapons.CrystalBalls
             Item.rare = ItemRarityID.Red;
             Item.shoot = ModContent.ProjectileType<OverloadLunarHoldout>();
             Item.shootSpeed = 16f;
-            Item.mana = 4;
+            Item.mana = 2;
             Item.DamageType = DamageClass.Magic;
         }
         public override void AddRecipes()


### PR DESCRIPTION
1.电熔炉面板降低至50，魔耗增加，配方里的光魂换成10个暗魂，加强了弹速
2.脉冲杖的面板提升至80，魔力消耗略降以适配散搭和初级蓝药
3.彼岸之眼的耗魔大幅降低，材料数目增加
4.重力凝视耗魔降低，弹速提升以应对蜂王和后期骷髅王
5.夜明星陨面板提升至80，魔耗减半