### PR TITLE
一点小改动

### DIFF
--- a/Content/Items/Donator/Gungnir.cs
+++ b/Content/Items/Donator/Gungnir.cs
@@ -48,7 +48,8 @@ namespace CalamityEntropy.Content.Items.Donator
         {
             Item.width = 120;
             Item.height = 120;
-            Item.damage = 1300;
+            Item.damage = 1000;
+            Item.crit = 10;
             Item.noMelee = true;
             Item.noUseGraphic = true;
             Item.useAnimation = Item.useTime = 30;
@@ -60,7 +61,7 @@ namespace CalamityEntropy.Content.Items.Donator
             Item.value = CalamityGlobalItem.RarityCalamityRedBuyPrice;
             Item.rare = ItemRarityID.Blue;
             Item.shoot = ModContent.ProjectileType<GungnirThrow>();
-            Item.shootSpeed = 42;
+            Item.shootSpeed = 28;
             Item.DamageType = DamageClass.Melee;
         }
     }
@@ -73,7 +74,8 @@ namespace CalamityEntropy.Content.Items.Donator
             Projectile.usesLocalNPCImmunity = true;
             Projectile.localNPCHitCooldown = -1;
             Projectile.MaxUpdates = 4;
-            Projectile.timeLeft = 60;
+            Projectile.penetrate = 7;
+            Projectile.timeLeft = 240;
         }
         public override bool? Colliding(Rectangle projHitbox, Rectangle targetHitbox)
         {
@@ -106,18 +108,18 @@ namespace CalamityEntropy.Content.Items.Donator
         {
             ScreenShaker.AddShake(new ScreenShaker.ScreenShake(Vector2.Zero, 6));
             EParticle.spawnNew(new DOracleSlash() { centerColor = Color.White }, Projectile.Center - Projectile.velocity * 0.8f, Vector2.Zero, new Color(122, 122, 255), Main.rand.NextFloat(380, 420), 1f, true, BlendState.Additive, Projectile.rotation + MathHelper.Pi, 8);
-            if (Projectile.ai[1]-- > -3)
+            if (Projectile.ai[1]-- > -1)
             {
                 CEUtils.PlaySound("ThunderStrike", Main.rand.NextFloat(0.8f, 1.2f), target.Center, 6, 0.4f);
                 CEUtils.PlaySound("ystn_hit", 2.7f, target.Center);
                 for (int i = 0; i < 8; i++)
                 {
                     Vector2 pos = target.Center + new Vector2(0, -900) + CEUtils.randomPointInCircle(600);
-                    Projectile.NewProjectile(Projectile.GetSource_FromThis(), pos, (target.Center - pos).normalize() * 42, ModContent.ProjectileType<AstralStarMelee>(), Projectile.damage / 4, Projectile.owner);
+                    Projectile.NewProjectile(Projectile.GetSource_FromThis(), pos, (target.Center - pos).normalize() * 42, ModContent.ProjectileType<AstralStarMelee>(), Projectile.damage / 6, Projectile.owner);
                 }
                 for (int i = 0; i < 1; i++)
                 {
-                    int lightningDamage = (int)(Projectile.damage * 0.6f);
+                    int lightningDamage = (int)(Projectile.damage * 1.25f);
                     Vector2 lightningSpawnPosition = Projectile.Center - Vector2.UnitY.RotatedByRandom(0.2f) * 1000f;
                     Vector2 lightningShootVelocity = (target.Center - lightningSpawnPosition + target.velocity * 7.5f).SafeNormalize(Vector2.UnitY) * 15f;
                     int lightning = Projectile.NewProjectile(Projectile.GetSource_FromThis(), lightningSpawnPosition, lightningShootVelocity, ModContent.ProjectileType<StormfrontLightning>(), lightningDamage, 0f, Projectile.owner);

--- a/Content/Items/Weapons/Aquashard.cs
+++ b/Content/Items/Weapons/Aquashard.cs
@@ -58,8 +58,8 @@ namespace CalamityEntropy.Content.Items.Weapons
 
         public override void AddRecipes()
         {
-            CreateRecipe().AddIngredient(ModContent.ItemType<SeaPrism>(), 8)
-                .AddIngredient(ModContent.ItemType<PearlShard>(), 4)
+            CreateRecipe().AddIngredient(ModContent.ItemType<PearlShard>(), 4)
+                .AddIngredient(ModContent.ItemType<SeaPrism>(), 8)
                 .AddTile(TileID.Anvils)
                 .Register();
         }

--- a/Content/Items/Weapons/AzureRapier.cs
+++ b/Content/Items/Weapons/AzureRapier.cs
@@ -35,7 +35,7 @@ namespace CalamityEntropy.Content.Items.Weapons
             Item.useAnimation = 6;
             Item.autoReuse = true;
             Item.scale = 2f;
-            Item.DamageType = ModContent.GetInstance<TrueMeleeDamageClass>();
+            Item.DamageType = DamageClass.Melee;
             Item.damage = 12;
             Item.knockBack = 4;
             Item.crit = 6;
@@ -70,9 +70,9 @@ namespace CalamityEntropy.Content.Items.Weapons
 
         public override void AddRecipes()
         {
-            CreateRecipe().AddIngredient<SeaPrism>(6)
+            CreateRecipe().AddIngredient<PearlShard>(4)
+                .AddIngredient<SeaPrism>(6)
                 .AddIngredient<CalamityMod.Items.Placeables.PrismShard>(10)
-                .AddIngredient<PearlShard>(4)
                 .AddTile(TileID.Anvils)
                 .Register();
         }
@@ -87,7 +87,7 @@ namespace CalamityEntropy.Content.Items.Weapons
         public override string Texture => "CalamityEntropy/Content/Items/Weapons/AzureRapier";
         public override void SetDefaults()
         {
-            Projectile.FriendlySetDefaults(ModContent.GetInstance<TrueMeleeDamageClass>(), false, -1);
+            Projectile.FriendlySetDefaults(DamageClass.Melee, false, -1);
             Projectile.usesLocalNPCImmunity = true;
             Projectile.localNPCHitCooldown = -1;
         }
@@ -193,7 +193,7 @@ namespace CalamityEntropy.Content.Items.Weapons
         public override string Texture => "CalamityEntropy/Content/Items/Weapons/AzureRapier";
         public override void SetDefaults()
         {
-            Projectile.FriendlySetDefaults(ModContent.GetInstance<TrueMeleeDamageClass>(), false, -1);
+            Projectile.FriendlySetDefaults(DamageClass.Melee, false, -1);
             Projectile.timeLeft = 60;
             Projectile.localNPCHitCooldown = 3;
             Projectile.usesLocalNPCImmunity = true;
@@ -245,7 +245,7 @@ namespace CalamityEntropy.Content.Items.Weapons
         public override string Texture => "CalamityEntropy/Content/Items/Weapons/AzureRapier";
         public override void SetDefaults()
         {
-            Projectile.FriendlySetDefaults(ModContent.GetInstance<TrueMeleeDamageClass>(), false, -1);
+            Projectile.FriendlySetDefaults(DamageClass.Melee, false, -1);
             Projectile.timeLeft = 24;
         }
         public float TScale = 0;

--- a/Content/Items/Weapons/CrystalBalls/EyeOfIlmeris.cs
+++ b/Content/Items/Weapons/CrystalBalls/EyeOfIlmeris.cs
@@ -33,8 +33,8 @@ namespace CalamityEntropy.Content.Items.Weapons.CrystalBalls
         public override void AddRecipes()
         {
             CreateRecipe()
-                .AddIngredient(ModContent.ItemType<SeaPrism>(), 5)
                 .AddIngredient(ModContent.ItemType<PearlShard>(), 2)
+                .AddIngredient(ModContent.ItemType<SeaPrism>(), 5)
                 .AddIngredient(ItemID.Glass, 10)
                 .AddTile(TileID.WorkBenches)
                 .Register();

--- a/Localization/zh-Hans/Mods.CalamityEntropy.hjson
+++ b/Localization/zh-Hans/Mods.CalamityEntropy.hjson
@@ -507,7 +507,7 @@ Items: {
 		Tooltip:
 			'''
 			用于制作[i:CalamityEntropy/OracleDeck][c/87CEFA:神谕卡组]
-			按住左Alt来查看卡组需求
+			按住左Shift来查看卡组需求
 			'''
 		DisplayName: 命运之绳
 		HoldShiftForDetails:
@@ -1097,7 +1097,7 @@ Items: {
 		DisplayName: 堕化卡组
 		Tooltip:
 			'''
-			盗贼弹幕获得追踪能力，但是盗贼属性大幅降低
+			盗贼弹幕获得追踪能力
 			攻击使敌人中蒙蔽debuff，减少其移动速度
 			攻击附带虚空之触减益
 			攻击时发射暗隐火焰
@@ -1117,7 +1117,7 @@ Items: {
 		Tooltip:
 			'''
 			用于制作[i:CalamityEntropy/TaintedDeck][c/FF6347:堕化卡组]
-			按住左Alt以查看卡组需求
+			按住左Shift以查看卡组需求
 			'''
 		HoldShiftForDetails:
 			'''


### PR DESCRIPTION
*把苍蓝刺剑的伤害类型从真近战改成了近战。理由是真近战属性打蠕虫和飞眼怪会有高额减伤，双条只吃一半加成。结果就是开条只能打掉血肉宿主的一根小虫子...的三分之一血。 
*在捐赠者的同意下平衡了冈格尼尔。
*修正了卡组绳子和堕化卡组的文本。
*调整了一下灾熵武器配方里珍珠碎片的位置，与灾厄保持一致。