### PR TITLE
Azafure武器的小改动

### DIFF
--- a/Content/Items/Accessories/AzafureChargeShield.cs
+++ b/Content/Items/Accessories/AzafureChargeShield.cs
@@ -64,7 +64,6 @@ namespace CalamityEntropy.Content.Items.Accessories
             CreateRecipe()
                 .AddIngredient<HellIndustrialComponents>(6)
                 .AddIngredient<DubiousPlating>(10)
-                .AddRecipeGroup(RecipeGroupID.IronBar, 10)
                 .AddIngredient<AerialiteBar>(5)
                 .AddIngredient(ItemID.HellstoneBar, 5)
                 .AddTile(TileID.Anvils)

--- a/Content/Items/Accessories/AzafureDetectionEquipment.cs
+++ b/Content/Items/Accessories/AzafureDetectionEquipment.cs
@@ -34,8 +34,8 @@ namespace CalamityEntropy.Content.Items.Accessories
         public override void AddRecipes()
         {
             CreateRecipe().
-                AddIngredient<HellIndustrialComponents>(4).
                 AddIngredient<RustyDetectionEquipment>().
+                AddIngredient<HellIndustrialComponents>(4).
                 AddIngredient<AerialiteBar>(8).
                 AddTile(TileID.Anvils).
                 Register();

--- a/Content/Items/AzafureMiner.cs
+++ b/Content/Items/AzafureMiner.cs
@@ -28,8 +28,8 @@ namespace CalamityEntropy.Content.Items
         public override void AddRecipes()
         {
             CreateRecipe().AddIngredient<EnergyCore>()
-                .AddIngredient<DubiousPlating>(6)
                 .AddIngredient<HellIndustrialComponents>(6)
+                .AddIngredient<DubiousPlating>(6)
                 .AddRecipeGroup(RecipeGroupID.IronBar, 2)
                 .AddTile(TileID.HeavyWorkBench)
                 .Register();

--- a/Content/Items/Books/AzafureCylinder.cs
+++ b/Content/Items/Books/AzafureCylinder.cs
@@ -28,7 +28,6 @@ namespace CalamityEntropy.Content.Items.Books
             CreateRecipe()
                 .AddIngredient<HellIndustrialComponents>(6)
                 .AddIngredient(ItemID.ManaCrystal)
-                .AddRecipeGroup(RecipeGroupID.IronBar, 6)
                 .AddIngredient(ItemID.HellstoneBar, 8)
                 .AddIngredient(ItemID.Obsidian, 6)
                 .AddTile(TileID.Hellforge)

--- a/Content/Items/Books/BookMarks/BookMarkMechanical.cs
+++ b/Content/Items/Books/BookMarks/BookMarkMechanical.cs
@@ -28,9 +28,9 @@ namespace CalamityEntropy.Content.Items.Books.BookMarks
         public override void AddRecipes()
         {
             CreateRecipe()
+            .AddIngredient(ModContent.ItemType<HellIndustrialComponents>(), 10)
             .AddIngredient(ItemID.SoulofNight, 10)
             .AddIngredient(ItemID.SoulofLight, 10)
-            .AddIngredient(ModContent.ItemType<HellIndustrialComponents>(), 10)
             .AddTile(TileID.MythrilAnvil)
             .Register();
         }

--- a/Content/Items/Donator/TlipocasScythe.cs
+++ b/Content/Items/Donator/TlipocasScythe.cs
@@ -411,7 +411,7 @@ namespace CalamityEntropy.Content.Items.Donator
             }
             Item.damage = dmg;
             Item.ClearNameOverride();
-            if (player.name.ToLower() is "tlipoca" || player.GetModPlayer<VanityModPlayer>().vanityEquippedLast == "BlackFlower")
+            if (player.name.ToLower() is "tlipoca" or "Kino" || player.GetModPlayer<VanityModPlayer>().vanityEquippedLast == "BlackFlower")
             {
                 Item.SetNameOverride(Mod.GetLocalization("TScytheSpecialName").Value);
             }
@@ -421,7 +421,7 @@ namespace CalamityEntropy.Content.Items.Donator
             }
             if (throwType == -1)
                 throwType = ModContent.ProjectileType<TlipocasScytheThrow>();
-            Item.useTime = Item.useAnimation = (44 - GetLevel()) / (SpeedUpTime > 0 ? 6 : 1);
+            Item.useTime = Item.useAnimation = (40 - GetLevel()) / (SpeedUpTime > 0 ? 6 : 1);
             FuncKilledTownNPC(player);           
         }
         private void FuncKilledTownNPC(Player player)
@@ -494,6 +494,7 @@ namespace CalamityEntropy.Content.Items.Donator
             {
                 Projectile.NewProjectile(source, position, velocity, ModContent.ProjectileType<TlipocasScytheHeld>(), DashUpgrade() ? damage : damage / 4, knockback, player.whoAmI, swing == 0 ? 1 : -1, -1);
                 player.AddCooldown(TlipocasScytheSlashCooldown.ID, 7 * 60);
+                CalamityEntropy.FlashEffectStrength = 0.3f;
                 int p = Projectile.NewProjectile(source, position, velocity.normalize() * 1000 * (DashUpgrade() ? 1.33f : 1), ModContent.ProjectileType<TSSlash>(), damage * 2, knockback, player.whoAmI);
                 if (player.Calamity().StealthStrikeAvailable() && p.WithinBounds(Main.maxProjectiles))
                 {
@@ -512,7 +513,7 @@ namespace CalamityEntropy.Content.Items.Donator
                 if (player.Calamity().StealthStrikeAvailable() && p.WithinBounds(Main.maxProjectiles))
                 {
                     Main.projectile[p].Calamity().stealthStrike = true;
-                    int ut = 44 - GetLevel();
+                    int ut = 40 - GetLevel();
                     SpeedUpTime += ut + (int)(ut * 0.35f);
                 }
                 CostStealthForPlr(player);
@@ -590,6 +591,7 @@ namespace CalamityEntropy.Content.Items.Donator
                 CEUtils.PlaySound("AbyssalBladeLaunch", 1, Projectile.Center);
             }
             Player player = Projectile.GetOwner();
+            CalamityEntropy.FlashEffectStrength = 0.3f;
             if (Projectile.ai[1] == 0 && MovePlayer)
             {
                 Vector2 odp = player.Center;
@@ -698,15 +700,16 @@ namespace CalamityEntropy.Content.Items.Donator
             {
                 SoundEngine.PlaySound(PerforatorHive.DeathSound, target.Center);
                 var player = Projectile.GetOwner();
-                player.QuickSpawnItem(target.GetSource_Death(), new Item(ItemID.SilverCoin, 10), 10);
-                player.QuickSpawnItem(target.GetSource_Death(), new Item(ModContent.ItemType<BloodOrb>(), 2), 2);
+                player.QuickSpawnItem(target.GetSource_Death(), new Item(73, 20), 20);
+                player.QuickSpawnItem(target.GetSource_Death(), new Item(ModContent.ItemType<BloodOrb>(), 30), 30);
                 if (NPC.downedPlantBoss)
                 {
-                    player.QuickSpawnItem(target.GetSource_Death(), new Item(1508, 2), 2);
+                    player.QuickSpawnItem(target.GetSource_Death(), new Item(1508, 20), 20);
+                    player.QuickSpawnItem(target.GetSource_Death(), new Item(74, 514), 20);
                 }
                 if (NPC.downedMoonlord)
                 {
-                    player.QuickSpawnItem(target.GetSource_Death(), new Item(ModContent.ItemType<Necroplasm>(), 2), 2);
+                    player.QuickSpawnItem(target.GetSource_Death(), new Item(ModContent.ItemType<Necroplasm>(), 20), 20);
                 }
             }
             if (flagS)
@@ -730,12 +733,18 @@ namespace CalamityEntropy.Content.Items.Donator
             {
                 target.AddBuff<VulnerabilityHex>(60 * 5);
             }
-            else
             if (DownedBossSystem.downedRavager)
             {
                 if (DownedBossSystem.downedProvidence)
                 {
-                    target.AddBuff<Shred>(60 * 5);
+                    if (DownedBossSystem.downedPrimordialWyrm)
+                    {
+                        target.AddBuff<LifeOppress>(60 * 5);
+                    }
+                    else
+                    {
+                        target.AddBuff<Koishi>(60 * 5);
+                    }
                 }
                 else
                 {
@@ -818,7 +827,7 @@ namespace CalamityEntropy.Content.Items.Donator
             int dir = (int)Projectile.ai[0] * Math.Sign(Projectile.velocity.X);
 
             float ySc = 0.6f;
-            ProjScale = 1.4f + TlipocasScythe.GetLevel() * 0.04f;
+            ProjScale = 1.56f + TlipocasScythe.GetLevel() * 0.04f;
             ProjScale *= (1 + Projectile.ai[1] * 0.5f);
             if (Projectile.ai[1] == 1)
             {
@@ -1079,12 +1088,18 @@ namespace CalamityEntropy.Content.Items.Donator
             {
                 target.AddBuff<VulnerabilityHex>(60 * 5);
             }
-            else
             if (DownedBossSystem.downedRavager)
             {
                 if (DownedBossSystem.downedProvidence)
                 {
-                    target.AddBuff<Shred>(60 * 5);
+                    if (DownedBossSystem.downedPrimordialWyrm)
+                    {
+                        target.AddBuff<LifeOppress>(60 * 5);
+                    }
+                    else
+                    {
+                        target.AddBuff<Koishi>(60 * 5);
+                    }
                 }
                 else
                 {
@@ -1102,14 +1117,14 @@ namespace CalamityEntropy.Content.Items.Donator
             GeneralParticleHandler.SpawnParticle(impactParticle);
 
 
-            float sparkCount = 14 + TlipocasScythe.GetLevel();
+            float sparkCount = 6 + TlipocasScythe.GetLevel();
             for (int i = 0; i < sparkCount; i++)
             {
                 float p = Main.rand.NextFloat();
                 Vector2 sparkVelocity2 = CEUtils.randomRot().ToRotationVector2().RotatedByRandom(p * 0.4f) * Main.rand.NextFloat(6, 20 * (2 - p)) * (1 + TlipocasScythe.GetLevel() * 0.1f);
-                int sparkLifetime2 = (int)((2 - p) * 16);
-                float sparkScale2 = 0.6f + (1 - p);
-                sparkScale2 *= (1 + TlipocasScythe.GetLevel() * 0.06f);
+                int sparkLifetime2 = (int)((2 - p) * 9);
+                float sparkScale2 = 0.4f + (1 - p);
+                sparkScale2 *= (1 + TlipocasScythe.GetLevel() * 0.03f);
                 Color sparkColor2 = Color.Lerp(Color.DarkRed, Color.IndianRed, p);
                 if (Projectile.GetOwner().HasBuff<VoidEmpowerment>())
                 {

--- a/Content/Items/Tools/AzafureDrill.cs
+++ b/Content/Items/Tools/AzafureDrill.cs
@@ -1,6 +1,7 @@
 ﻿using CalamityEntropy.Content.Items.Armor.Azafure;
 using CalamityMod;
 using CalamityMod.Items;
+using CalamityMod.Items.Materials;
 using System;
 using Terraria;
 using Terraria.ID;
@@ -38,6 +39,7 @@ namespace CalamityEntropy.Content.Items.Tools
         {
             CreateRecipe().
                 AddIngredient<HellIndustrialComponents>(4).
+                AddIngredient<DubiousPlating>(6).
                 AddRecipeGroup(RecipeGroupID.IronBar, 6).
                 AddTile(TileID.Anvils).
                 Register();

--- a/Content/Items/Weapons/AzafureAirReaper.cs
+++ b/Content/Items/Weapons/AzafureAirReaper.cs
@@ -26,7 +26,7 @@ namespace CalamityEntropy.Content.Items.Weapons
         {
             Item.width = 78;
             Item.height = 78;
-            Item.damage = 15;
+            Item.damage = 12;
             Item.DamageType = CEUtils.RogueDC;
             Item.useTime = 32;
             Item.useAnimation = 32;
@@ -49,8 +49,8 @@ namespace CalamityEntropy.Content.Items.Weapons
         {
             CreateRecipe()
                 .AddIngredient<HellIndustrialComponents>(5)
-                .AddRecipeGroup(RecipeGroupID.IronBar, 8)
                 .AddIngredient<MysteriousCircuitry>(4)
+                .AddRecipeGroup(RecipeGroupID.IronBar, 8)
                 .AddTile(TileID.Anvils)
                 .Register();
         }

--- a/Content/Items/Weapons/AzafureBatteringRam.cs
+++ b/Content/Items/Weapons/AzafureBatteringRam.cs
@@ -47,7 +47,6 @@ namespace CalamityEntropy.Content.Items.Weapons
                 .AddIngredient<DubiousPlating>(10)
                 .AddIngredient<AerialiteBar>(5)
                 .AddIngredient(ItemID.HellstoneBar, 18)
-                .AddRecipeGroup(RecipeGroupID.IronBar, 20)
                 .AddTile(TileID.Anvils)
                 .Register();
         }

--- a/Content/Items/Weapons/AzafureDroneRemote.cs
+++ b/Content/Items/Weapons/AzafureDroneRemote.cs
@@ -63,9 +63,8 @@ namespace CalamityEntropy.Content.Items.Weapons
                 .AddIngredient<HellIndustrialComponents>(6)
                 .AddIngredient<MysteriousCircuitry>()
                 .AddIngredient<AerialiteBar>(8)
-                .AddRecipeGroup(RecipeGroupID.IronBar, 8)
                 .AddIngredient<EnergyCore>()
-                .AddIngredient(ItemID.Dynamite, 2)
+                .AddIngredient(ItemID.Dynamite, 1)
                 .AddTile(TileID.Anvils)
                 .Register();
         }

--- a/Content/Items/Weapons/AzafureEKatana.cs
+++ b/Content/Items/Weapons/AzafureEKatana.cs
@@ -41,9 +41,9 @@ namespace CalamityEntropy.Content.Items.Weapons
             Item.useAnimation = 10;
             Item.autoReuse = true;
             Item.DamageType = ModContent.GetInstance<TrueMeleeDamageClass>();
-            Item.damage = 68;
+            Item.damage = 120;
             Item.knockBack = 4;
-            Item.crit = 7;
+            Item.crit = 15;
             Item.channel = true;
             Item.shoot = ModContent.ProjectileType<AzafureEKatanaSlash>();
             Item.shootSpeed = 12;
@@ -59,8 +59,8 @@ namespace CalamityEntropy.Content.Items.Weapons
         {
             CreateRecipe()
                 .AddIngredient<HellIndustrialComponents>(4)
-                .AddIngredient(ItemID.HellstoneBar, 8)
                 .AddIngredient(ItemID.TitaniumBar, 8)
+                .AddIngredient(ItemID.HellstoneBar, 8)
                 .AddTile(TileID.MythrilAnvil)
                 .Register();
         }

--- a/Content/Items/Weapons/AzafureFurnace.cs
+++ b/Content/Items/Weapons/AzafureFurnace.cs
@@ -38,8 +38,8 @@ namespace CalamityEntropy.Content.Items.Weapons
         public override void AddRecipes()
         {
             CreateRecipe().
-                AddIngredient<HellIndustrialComponents>(4).
                 AddIngredient<OverloadFurnace>().
+                AddIngredient<HellIndustrialComponents>(4).
                 AddIngredient(ItemID.SoulofNight, 10).
                 AddTile(TileID.MythrilAnvil).
                 Register();

--- a/Content/Items/Weapons/AzafureHealingTowerRemote.cs
+++ b/Content/Items/Weapons/AzafureHealingTowerRemote.cs
@@ -18,7 +18,7 @@ namespace CalamityEntropy.Content.Items.Weapons
         {
             Item.width = 26;
             Item.height = 56;
-            Item.damage = 5;
+            Item.damage = 7;
             Item.mana = 10;
             Item.useTime = Item.useAnimation = 25;
             Item.useStyle = ItemUseStyleID.RaiseLamp;
@@ -104,7 +104,7 @@ namespace CalamityEntropy.Content.Items.Weapons
                 AttackMode = false;
                 if (CheckCD <= 0)
                 {
-                    CheckCD = (int)(25f * (100f / player.GetTotalDamage(DamageClass.Summon).ApplyTo(100f)) * (1 - 0.5f * player.AzafureDurability()));
+                    CheckCD = (int)(30f * (100f / player.GetTotalDamage(DamageClass.Summon).ApplyTo(100f)) * (1 - 0.5f * player.AzafureDurability()));
                     healing.Heal(1);
                     for (int i = 0; i < 3; i++)
                         EParticle.spawnNew(new HealingParticle(), healing.position + CEUtils.randomPoint(new Rectangle(-6, -6, 12 + healing.width, 12 + healing.height)), new Vector2(0, -2), Color.White, 0.8f, 1, true, BlendState.AlphaBlend);

--- a/Content/Items/Weapons/AzafureMissleLauncher/AzafureTacticalRadio.cs
+++ b/Content/Items/Weapons/AzafureMissleLauncher/AzafureTacticalRadio.cs
@@ -21,7 +21,7 @@ namespace CalamityEntropy.Content.Items.Weapons.AzafureMissleLauncher
         {
             Item.width = 38;
             Item.height = 32;
-            Item.damage = 80;
+            Item.damage = 100;
             Item.mana = 0;
             Item.useTime = Item.useAnimation = 20;
             Item.useStyle = ItemUseStyleID.RaiseLamp;
@@ -52,6 +52,7 @@ namespace CalamityEntropy.Content.Items.Weapons.AzafureMissleLauncher
         {
             CreateRecipe()
                 .AddIngredient<HellIndustrialComponents>(8)
+                .AddIngredient<MysteriousCircuitry>(4)
                 .AddIngredient(ItemID.HallowedBar, 10)
                 .AddTile(TileID.MythrilAnvil)
                 .Register();

--- a/Content/Items/Weapons/AzafurePioneerCannon.cs
+++ b/Content/Items/Weapons/AzafurePioneerCannon.cs
@@ -51,8 +51,8 @@ namespace CalamityEntropy.Content.Items.Weapons
         public override void AddRecipes()
         {
             CreateRecipe()
-                .AddIngredient<HellIndustrialComponents>(4)
                 .AddIngredient<AzafureAntiaircraftGun>()
+                .AddIngredient<HellIndustrialComponents>(4)
                 .AddIngredient<DivineGeode>(6)
                 .AddIngredient(ItemID.LunarBar, 8)
                 .AddTile(TileID.LunarCraftingStation)

--- a/Content/Items/Weapons/AzafurePulseWand.cs
+++ b/Content/Items/Weapons/AzafurePulseWand.cs
@@ -44,8 +44,8 @@ namespace CalamityEntropy.Content.Items.Weapons
         public override void AddRecipes()
         {
             CreateRecipe()
-                .AddIngredient<HellIndustrialComponents>(4)
                 .AddIngredient<PlasmaRod>()
+                .AddIngredient<HellIndustrialComponents>(4)
                 .AddIngredient<AerialiteBar>(5)
                 .AddTile(TileID.Anvils)
                 .Register();

--- a/Content/Items/Weapons/Cogfly/AzafureCogfly.cs
+++ b/Content/Items/Weapons/Cogfly/AzafureCogfly.cs
@@ -57,8 +57,8 @@ namespace CalamityEntropy.Content.Items.Weapons.Cogfly
         public override void AddRecipes()
         {
             CreateRecipe().AddIngredient<HellIndustrialComponents>(4)
-                .AddRecipeGroup(RecipeGroupID.IronBar, 4)
                 .AddIngredient<MysteriousCircuitry>()
+                .AddRecipeGroup(RecipeGroupID.IronBar, 4)
                 .AddTile(TileID.Anvils)
                 .Register();
         }

--- a/Content/Items/Weapons/ElectrocauteryWand/AzafureElectrocauteryWand.cs
+++ b/Content/Items/Weapons/ElectrocauteryWand/AzafureElectrocauteryWand.cs
@@ -40,9 +40,9 @@ namespace CalamityEntropy.Content.Items.Weapons.ElectrocauteryWand
         public override void AddRecipes()
         {
             CreateRecipe()
-                .AddRecipeGroup(CERecipeGroups.AnyOrichalcumBar, 8)
-                .AddIngredient<HellIndustrialComponents>(6)
                 .AddIngredient<AzafurePulseWand>()
+                .AddIngredient<HellIndustrialComponents>(6)
+                .AddRecipeGroup(CERecipeGroups.AnyOrichalcumBar, 8)
                 .AddTile(TileID.Anvils)
                 .Register();
         }


### PR DESCRIPTION
*整理了Azafure系列的物品合成表
*大幅提高了电太刀的面板（68 -> 120)
*削弱了小小镰刀的面板（15 -> 12) (不然他成天蓝强度了）
*延长了治疗塔的cd（25 -> 30）但是增加了面板（5 ->7)
*哈哈还有增强了kino（的小镰刀）