### PR TITLE
111

### DIFF
--- a/Common/EGlobalProjectile.cs
+++ b/Common/EGlobalProjectile.cs
@@ -1463,7 +1463,7 @@ namespace CalamityEntropy.Common
                     if (plr.MagiShield <= 0)
                     {
                         plr.HMRegenCd = 40;
-                        projectile.owner.ToPlayer().Heal(projectile.owner.ToPlayer().statManaMax2 / 100);
+                        projectile.owner.ToPlayer().Heal(projectile.owner.ToPlayer().statManaMax2 / 350 + 5);
                     }
                 }
                 if (plr.VFHelmMagic && projectile.owner >= 0)

--- a/Common/EGlobalProjectile.cs
+++ b/Common/EGlobalProjectile.cs
@@ -1462,7 +1462,7 @@ namespace CalamityEntropy.Common
                 {
                     if (plr.MagiShield <= 0)
                     {
-                        plr.HMRegenCd = 40;
+                        plr.HMRegenCd = 60;
                         projectile.owner.ToPlayer().Heal(projectile.owner.ToPlayer().statManaMax2 / 350 + 5);
                     }
                 }

--- a/Content/Items/Donator/Gungnir.cs
+++ b/Content/Items/Donator/Gungnir.cs
@@ -47,7 +47,7 @@ namespace CalamityEntropy.Content.Items.Donator
         {
             Item.width = 120;
             Item.height = 120;
-            Item.damage = 1000;
+            Item.damage = 800;
             Item.crit = 10;
             Item.noMelee = true;
             Item.noUseGraphic = true;

--- a/Content/Items/Donator/RocketLauncher/Ammo/AerialiteMissile.cs
+++ b/Content/Items/Donator/RocketLauncher/Ammo/AerialiteMissile.cs
@@ -15,10 +15,10 @@ namespace CalamityEntropy.Content.Items.Donator.RocketLauncher.Ammo
             Item.width = 24;
             Item.height = 24;
             Item.maxStack = 9999;
-            Item.value = Item.sellPrice(silver: 5);
+            Item.value = Item.sellPrice(copper: 6);
             Item.rare = ItemRarityID.Orange;
             Item.ammo = BaseMissileProj.AmmoType;
-            Item.damage = 6;
+            Item.damage = 7;
             Item.shoot = ModContent.ProjectileType<AerialiteMissileProj>();
             Item.consumable = true;
             Item.DamageType = DamageClass.Ranged;
@@ -35,6 +35,7 @@ namespace CalamityEntropy.Content.Items.Donator.RocketLauncher.Ammo
     }
     public class AerialiteMissileProj : BaseMissileProj
     {
+	    public override float StickDamageAddition => 0.02f;
         public override string Texture => "CalamityEntropy/Content/Items/Donator/RocketLauncher/Ammo/AerialiteMissile";
         public override void SetupStats()
         {

--- a/Content/Items/Donator/RocketLauncher/Ammo/AzafureMissile.cs
+++ b/Content/Items/Donator/RocketLauncher/Ammo/AzafureMissile.cs
@@ -16,10 +16,10 @@ namespace CalamityEntropy.Content.Items.Donator.RocketLauncher.Ammo
             Item.width = 24;
             Item.height = 24;
             Item.maxStack = 9999;
-            Item.value = Item.sellPrice(silver: 5);
+            Item.value = Item.sellPrice(copper: 5);
             Item.rare = ItemRarityID.Orange;
             Item.ammo = BaseMissileProj.AmmoType;
-            Item.damage = 9;
+            Item.damage = 11;
             Item.shoot = ModContent.ProjectileType<AzafureMissileProj>();
             Item.consumable = true;
             Item.DamageType = DamageClass.Ranged;
@@ -36,7 +36,7 @@ namespace CalamityEntropy.Content.Items.Donator.RocketLauncher.Ammo
     }
     public class AzafureMissileProj : BaseMissileProj
     {
-        public override float StickDamageAddition => 0.07f;
+        public override float StickDamageAddition => 0.02f;
         public override float StickDamageMult => 0.16f;
         public override void SetupStats()
         {

--- a/Content/Items/Donator/RocketLauncher/Ammo/CharredMissile.cs
+++ b/Content/Items/Donator/RocketLauncher/Ammo/CharredMissile.cs
@@ -13,10 +13,10 @@ namespace CalamityEntropy.Content.Items.Donator.RocketLauncher.Ammo
             Item.width = 24;
             Item.height = 24;
             Item.maxStack = 9999;
-            Item.value = Item.sellPrice(silver: 1);
+            Item.value = Item.sellPrice(copper: 3);
             Item.rare = ItemRarityID.Orange;
             Item.ammo = BaseMissileProj.AmmoType;
-            Item.damage = 8;
+            Item.damage = 9;
             Item.shoot = ModContent.ProjectileType<CharredMissileProj>();
             Item.consumable = true;
             Item.DamageType = DamageClass.Ranged;
@@ -33,7 +33,7 @@ namespace CalamityEntropy.Content.Items.Donator.RocketLauncher.Ammo
     }
     public class CharredMissileProj : BaseMissileProj
     {
-        public override float StickDamageAddition => 0.05f;
+        public override float StickDamageAddition => 0.02f;
         public override string Texture => "CalamityEntropy/Content/Items/Donator/RocketLauncher/Ammo/CharredMissile";
     }
 }

--- a/Content/Items/Donator/RocketLauncher/Ammo/ClusterMissile.cs
+++ b/Content/Items/Donator/RocketLauncher/Ammo/ClusterMissile.cs
@@ -16,10 +16,10 @@ namespace CalamityEntropy.Content.Items.Donator.RocketLauncher.Ammo
             Item.width = 24;
             Item.height = 24;
             Item.maxStack = 9999;
-            Item.value = Item.sellPrice(silver: 5);
+            Item.value = Item.sellPrice(copper: 12);
             Item.rare = ItemRarityID.Orange;
             Item.ammo = BaseMissileProj.AmmoType;
-            Item.damage = 10;
+            Item.damage = 11;
             Item.shoot = ModContent.ProjectileType<ClusterMissileProj>();
             Item.consumable = true;
             Item.DamageType = DamageClass.Ranged;
@@ -96,7 +96,7 @@ namespace CalamityEntropy.Content.Items.Donator.RocketLauncher.Ammo
     }
     public class ClusterMissileSmall : BaseMissileProj
     {
-        public override float StickDamageAddition => 0.03f;
+        public override float StickDamageAddition => 0.01f;
         public override void SetupStats()
         {
             Projectile.ai[1] += 20;
@@ -111,7 +111,7 @@ namespace CalamityEntropy.Content.Items.Donator.RocketLauncher.Ammo
         public override void ModifyHitNPC(NPC target, ref NPC.HitModifiers modifiers)
         {
             base.ModifyHitNPC(target, ref modifiers);
-            modifiers.ArmorPenetration += 32;
+            modifiers.ArmorPenetration += 15;
         }
         public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
         {

--- a/Content/Items/Donator/RocketLauncher/Ammo/HallowedMissile.cs
+++ b/Content/Items/Donator/RocketLauncher/Ammo/HallowedMissile.cs
@@ -17,10 +17,10 @@ namespace CalamityEntropy.Content.Items.Donator.RocketLauncher.Ammo
             Item.width = 24;
             Item.height = 24;
             Item.maxStack = 9999;
-            Item.value = Item.sellPrice(silver: 5);
+            Item.value = Item.sellPrice(copper: 14);
             Item.rare = ItemRarityID.Orange;
             Item.ammo = BaseMissileProj.AmmoType;
-            Item.damage = 9;
+            Item.damage = 17;
             Item.shoot = ModContent.ProjectileType<HallowedMissileProj>();
             Item.consumable = true;
             Item.DamageType = DamageClass.Ranged;
@@ -28,25 +28,30 @@ namespace CalamityEntropy.Content.Items.Donator.RocketLauncher.Ammo
 
         public override void AddRecipes()
         {
-            CreateRecipe(25)
+            CreateRecipe(250)
                 .AddIngredient(ItemID.HallowedBar)
-                .AddIngredient(ModContent.ItemType<CharredMissile>(), 25)
-                .AddTile(TileID.Anvils)
+                .AddIngredient(ModContent.ItemType<CharredMissile>(), 250)
+                .AddTile(TileID.MythrilAnvil)
                 .Register();
         }
     }
     public class HallowedMissileProj : BaseMissileProj
     {
-        public override float StickDamageAddition => 0.07f;
+        public override float StickDamageAddition => 0.03f;
         public override void SetupStats()
         {
             Projectile.ai[1] += 100;
         }
         public override string Texture => "CalamityEntropy/Content/Items/Donator/RocketLauncher/Ammo/HallowedMissile";
+        public override void ModifyHitNPC(NPC target, ref NPC.HitModifiers modifiers)
+        {
+            base.ModifyHitNPC(target, ref modifiers);
+            modifiers.ArmorPenetration += 20;
+        }
         public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
         {
             base.OnHitNPC(target, hit, damageDone);
-            target.AddBuff<MechanicalTrauma>(5 * 60);
+            target.AddBuff(BuffID.OnFire3, 10 * 60);
         }
         public override void ExplodeVisual()
         {

--- a/Content/Items/Donator/RocketLauncher/Ammo/WulfrumMissile.cs
+++ b/Content/Items/Donator/RocketLauncher/Ammo/WulfrumMissile.cs
@@ -12,10 +12,10 @@ namespace CalamityEntropy.Content.Items.Donator.RocketLauncher.Ammo
             Item.width = 24;
             Item.height = 24;
             Item.maxStack = 9999;
-            Item.value = Item.sellPrice(silver: 5);
+            Item.value = Item.sellPrice(copper: 1);
             Item.rare = ItemRarityID.Orange;
             Item.ammo = BaseMissileProj.AmmoType;
-            Item.damage = 4;
+            Item.damage = 6;
             Item.shoot = ModContent.ProjectileType<WulfrumMissileProj>();
             Item.consumable = true;
             Item.DamageType = DamageClass.Ranged;
@@ -33,6 +33,7 @@ namespace CalamityEntropy.Content.Items.Donator.RocketLauncher.Ammo
     }
     public class WulfrumMissileProj : BaseMissileProj
     {
+	    public override float StickDamageAddition => 0.01f;
         public override string Texture => "CalamityEntropy/Content/Items/Donator/RocketLauncher/Ammo/WulfrumMissile";
         public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
         {

--- a/Content/Items/Donator/RocketLauncher/Zeal.cs
+++ b/Content/Items/Donator/RocketLauncher/Zeal.cs
@@ -25,7 +25,7 @@ namespace CalamityEntropy.Content.Items.Donator.RocketLauncher
             Item.width = 90;
             Item.height = 42;
             Item.DamageType = DamageClass.Ranged;
-            Item.damage = 130;
+            Item.damage = 85;
             Item.knockBack = 4f;
             Item.UseSound = CEUtils.GetSound("ProminenceShoot", 1.6f, 2, 0.5f);
             Item.value = Item.buyPrice(gold: 20);

--- a/Content/Items/Donator/Typhoon.cs
+++ b/Content/Items/Donator/Typhoon.cs
@@ -22,7 +22,7 @@ namespace CalamityEntropy.Content.Items.Donator
         {
             Item.width = 136;
             Item.height = 52;
-            Item.damage = 22;
+            Item.damage = 13;
             Item.DamageType = DamageClass.Ranged;
             Item.useTime = 1;
             Item.useAnimation = 1;
@@ -36,7 +36,7 @@ namespace CalamityEntropy.Content.Items.Donator
             Item.shoot = ProjectileID.Bullet;
             Item.shootSpeed = 16f;
             Item.useAmmo = AmmoID.Bullet;
-            Item.crit = 2;
+            Item.crit = 5;
             Item.ArmorPenetration = 10000;
         }
         public int mode = 0;

--- a/Content/Items/Weapons/LightWisper.cs
+++ b/Content/Items/Weapons/LightWisper.cs
@@ -15,7 +15,7 @@ namespace CalamityEntropy.Content.Items.Weapons
         {
             Item.width = 72;
             Item.height = 36;
-            Item.damage = 340;
+            Item.damage = 320;
             Item.DamageType = DamageClass.Ranged;
             Item.useTime = 3;
             Item.useAnimation = 18;

--- a/Content/Items/Weapons/OblivionThresher/OblivionThresher.cs
+++ b/Content/Items/Weapons/OblivionThresher/OblivionThresher.cs
@@ -21,7 +21,7 @@ namespace CalamityEntropy.Content.Items.Weapons.OblivionThresher
         {
             Item.width = 84;
             Item.height = 46;
-            Item.damage = 1720;
+            Item.damage = 850;
             Item.DamageType = DamageClass.Ranged;
             Item.useTime = 30;
             Item.useAnimation = 30;

--- a/Content/Items/Weapons/TrueMoonlightSword.cs
+++ b/Content/Items/Weapons/TrueMoonlightSword.cs
@@ -17,7 +17,7 @@ namespace CalamityEntropy.Content.Items.Weapons
     {
         public override void SetDefaults()
         {
-            Item.damage = 160;
+            Item.damage = 130;
             Item.DamageType = ModContent.GetInstance<MeleeDamageClass>();
             Item.width = 48;
             Item.height = 60;

--- a/Localization/en-US/Mods.CalamityEntropy.hjson
+++ b/Localization/en-US/Mods.CalamityEntropy.hjson
@@ -3448,7 +3448,7 @@ Items: {
 
 	CharredMissile: {
 		DisplayName: Charred Missile
-		Tooltip: +5% Damage each attached projectile
+		Tooltip: +2% Damage each attached projectile
 	}
 
 	OsseousRemains: {
@@ -3799,7 +3799,7 @@ Items: {
 		DisplayName: Azafure Missile
 		Tooltip:
 			'''
-			+7% Damage each attached projectile
+			+2% Damage each attached projectile
 			Causing more adhering damage
 			'''
 	}
@@ -3898,12 +3898,12 @@ Items: {
 
 	HellstoneMissile: {
 		DisplayName: Hellstone Missile
-		Tooltip: +5% Damage each attached projectile
+		Tooltip: +2% Damage each attached projectile
 	}
 
 	WulfrumMissile: {
 		DisplayName: Wulfrum Missile
-		Tooltip: +5% Damage each attached projectile
+		Tooltip: +1% Damage each attached projectile
 	}
 
 	CursedRunestone: {
@@ -4013,7 +4013,7 @@ Items: {
 		Tooltip:
 			'''
 			Spawn feathers when explode
-			+5% Damage each attached projectile
+			+2% Damage each attached projectile
 			'''
 	}
 
@@ -4024,7 +4024,7 @@ Items: {
 			Explosion after a period of time or on-hit
 			Split to 5 small missile that chasing enemies when explode
 			+100% max adhered missile
-			+3% Damage each attached projectile
+			+1% Damage each attached projectile
 			'''
 	}
 
@@ -4043,7 +4043,7 @@ Items: {
 		Tooltip:
 			'''
 			Has more explode radius
-			+7% Damage each attached projectile
+			+3% Damage each attached projectile
 			'''
 	}
 

--- a/Localization/zh-Hans/Mods.CalamityEntropy.hjson
+++ b/Localization/zh-Hans/Mods.CalamityEntropy.hjson
@@ -4288,8 +4288,8 @@ Items: {
 	}
 
 	AzafurePhonograph: {
-		// DisplayName: Azafure Phonograph
-		// Tooltip: ""
+		DisplayName: 阿萨福勒留声机
+		Tooltip: "播放阿萨福勒卫城机甲的主题曲"
 	}
 }
 

--- a/Localization/zh-Hans/Mods.CalamityEntropy.hjson
+++ b/Localization/zh-Hans/Mods.CalamityEntropy.hjson
@@ -3678,7 +3678,7 @@ Items: {
 
 	CharredMissile: {
 		DisplayName: 焦黑导弹
-		Tooltip: 每个黏附的射弹增加5%目标受到伤害
+		Tooltip: 每个黏附的射弹增加2%目标受到伤害
 	}
 
 	OsseousRemains: {
@@ -4045,7 +4045,7 @@ Items: {
 		DisplayName: 阿萨福勒导弹
 		Tooltip:
 			'''
-			每个黏附的射弹增加7%目标受到伤害
+			每个黏附的射弹增加2%目标受到伤害
 			造成更高的黏附伤害
 			-1黏附上限
 			'''
@@ -4146,12 +4146,12 @@ Items: {
 
 	HellstoneMissile: {
 		DisplayName: 狱炎导弹
-		Tooltip: 每个黏附的射弹增加5%目标受到伤害
+		Tooltip: 每个黏附的射弹增加2%目标受到伤害
 	}
 
 	WulfrumMissile: {
 		DisplayName: 钨钢导弹
-		Tooltip: 每个黏附的射弹增加5%目标受到伤害
+		Tooltip: 每个黏附的射弹增加1%目标受到伤害
 	}
 
 	CursedRunestone: {
@@ -4253,7 +4253,7 @@ Items: {
 		Tooltip:
 			'''
 			爆炸时生成羽毛
-			每个黏附的射弹增加5%目标受到伤害
+			每个黏附的射弹增加2%目标受到伤害
 			'''
 	}
 
@@ -4264,7 +4264,7 @@ Items: {
 			飞行一段时间或命中后爆炸
 			爆炸时分裂出5发追踪小型导弹
 			小型导弹可黏附在目标身上，并拥有两倍的黏附上限
-			每个黏附的小型导弹增加3%目标受到伤害
+			每个黏附的小型导弹增加1%目标受到伤害
 			'''
 	}
 
@@ -4283,13 +4283,13 @@ Items: {
 		Tooltip:
 			'''
 			具有更大的爆炸半径
-			每个黏附的射弹增加7%目标受到伤害
+			每个黏附的射弹增加3%目标受到伤害
 			'''
 	}
 
 	AzafurePhonograph: {
-		DisplayName: 阿萨福勒留声机
-		Tooltip: "播放阿萨福勒卫城机甲的主题曲"
+		// DisplayName: Azafure Phonograph
+		// Tooltip: ""
 	}
 }
 


### PR DESCRIPTION
1.冈枪，面板降低至800，由于新版本犽戎的22%免伤消失，相对肉度降低，且冈枪对单伤害过高甚至能与虚空分形比较，因此降低至携序剑对单水平
2.热忱，面板降低至85，对标飓风
3.怯污，面板降低至275，对标白羊座
4.飓风，使配方与夜明武器一致，面板降低至13，基础暴击率提升至5，对标黄金之鹰
5.所有火箭弹的面板进行提升并且重新分配叠层伤害：（避免叠伤害过高导致一些衍生弹幕伤害爆炸）
钨钢1%标记伤害。焦黑2%但面板提升至9。阿萨辐勒和熔岩2%但面板提升至11。天蓝2%但面板提升至7。集束炸弹1%但是面板提升至11，穿甲降低至15。神圣3%，配方修改为250:1，面板提升至17，给予20护甲穿透，造成10秒燃烧而非机械损伤。重写所有导弹的价格使其与灾厄弹药价格相匹配。
6.旋锯，面板降低至850，目前强度过高，在合理搭配曙玟的情况下对单伤害甚至能超过40万，将其不用曙玟的伤害降低至10万左右，用曙玟的伤害降低至18万
7.渺光，面板降低至320，对标焰烬虹光
8.真月光，面板降低至130，对标巨剑夜光
9.圣洁月光的回血公式修改为魔力/350+5，cd修改为60帧，提高吸血下限，使其能与混乱石更加适配