### PR TITLE
结合灾厄新版本亵渎战变化，大部分月前boss削弱和真近战调整做出的2.21适配改动

### DIFF
--- a/Common/EModPlayer.cs
+++ b/Common/EModPlayer.cs
@@ -1761,9 +1761,9 @@ namespace CalamityEntropy.Common
                 {
                     if (p.Distance(Player.Center) <= 300)
                     {
-                        Player.lifeRegen += 8;
-                        Player.endurance += 0.05f;
-                        Player.GetDamage(DamageClass.Generic) += 0.15f;
+                        Player.lifeRegen += 2;
+                        Player.endurance += 0.04f;
+                        Player.GetDamage(DamageClass.Generic) += 0.08f;
                     }
                 }
             }

--- a/Content/Items/Donator/TheFilthyContractWithMammon.cs
+++ b/Content/Items/Donator/TheFilthyContractWithMammon.cs
@@ -1,4 +1,4 @@
-﻿using CalamityEntropy.Content.Particles;
+using CalamityEntropy.Content.Particles;
 using CalamityMod;
 using CalamityMod.Items;
 using CalamityMod.Particles;
@@ -26,7 +26,7 @@ namespace CalamityEntropy.Content.Items.Donator
         {
             Item.width = 52;
             Item.height = 52;
-            Item.damage = 300;
+            Item.damage = 225;
             Item.DamageType = DamageClass.Magic;
             Item.useTime = 16;
             Item.useAnimation = 16;
@@ -35,6 +35,7 @@ namespace CalamityEntropy.Content.Items.Donator
             Item.noMelee = true;
             Item.noUseGraphic = true;
             Item.knockBack = 5f;
+            Item.mana = 500;
             Item.value = CalamityGlobalItem.RarityCalamityRedBuyPrice;
             Item.rare = ModContent.RarityType<CalamityRed>();
             Item.shootSpeed = 16f;

--- a/Content/Items/Weapons/AntiVoid.cs
+++ b/Content/Items/Weapons/AntiVoid.cs
@@ -39,7 +39,7 @@ namespace CalamityEntropy.Content.Items.Weapons
             Item.autoReuse = true;
             Item.scale = 2f;
             Item.DamageType = ModContent.GetInstance<TrueMeleeDamageClass>();
-            Item.damage = 394;
+            Item.damage = 325;
             Item.knockBack = 6;
             Item.crit = 44;
             Item.shoot = ModContent.ProjectileType<AntivoidSlash>();

--- a/Content/Items/Weapons/AzureRapier.cs
+++ b/Content/Items/Weapons/AzureRapier.cs
@@ -34,7 +34,7 @@ namespace CalamityEntropy.Content.Items.Weapons
             Item.useAnimation = 6;
             Item.autoReuse = true;
             Item.scale = 1f;
-            Item.DamageType = DamageClass.Melee;
+            Item.DamageType = ModContent.GetInstance<TrueMeleeDamageClass>();
             Item.damage = 10;
             Item.knockBack = 5;
             Item.crit = 6;

--- a/Content/Items/Weapons/BuriedSun.cs
+++ b/Content/Items/Weapons/BuriedSun.cs
@@ -1,4 +1,4 @@
-﻿using CalamityEntropy.Content.Rarities;
+using CalamityEntropy.Content.Rarities;
 using CalamityMod;
 using CalamityMod.Dusts;
 using CalamityMod.Enums;
@@ -36,7 +36,7 @@ namespace CalamityEntropy.Content.Items.Weapons
         {
             Item.width = 134;
             Item.height = 38;
-            Item.damage = 105;
+            Item.damage = 120;
             Item.DamageType = DamageClass.Ranged;
             Item.useTime = 9;
             Item.useAnimation = 9;
@@ -61,8 +61,8 @@ namespace CalamityEntropy.Content.Items.Weapons
 
         public override void AddRecipes()
         {
-            CreateRecipe().AddIngredient(ModContent.ItemType<MeldBlob>(), 20)
-                .AddIngredient(ItemID.FragmentVortex, 6)
+            CreateRecipe()
+                .AddIngredient(ModContent.ItemType<MeldBlob>(), 18)
                 .AddTile(TileID.LunarCraftingStation)
                 .Register();
         }

--- a/Content/Items/Weapons/Chainsaw/EnslavedStar.cs
+++ b/Content/Items/Weapons/Chainsaw/EnslavedStar.cs
@@ -11,7 +11,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Chainsaw
     {
         public override void SetDefaults()
         {
-            Item.damage = 110;
+            Item.damage = 70;
             Item.DamageType = ModContent.GetInstance<TrueMeleeDamageClass>();
             Item.width = 42;
             Item.height = 42;

--- a/Content/Items/Weapons/Chainsaw/Euangelion.cs
+++ b/Content/Items/Weapons/Chainsaw/Euangelion.cs
@@ -11,7 +11,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Chainsaw
     {
         public override void SetDefaults()
         {
-            Item.damage = 280;
+            Item.damage = 230;
             Item.DamageType = ModContent.GetInstance<TrueMeleeDamageClass>();
             Item.width = 42;
             Item.height = 42;

--- a/Content/Items/Weapons/Depletion/Depletion.cs
+++ b/Content/Items/Weapons/Depletion/Depletion.cs
@@ -1,6 +1,7 @@
-﻿using CalamityEntropy.Content.Particles;
+using CalamityEntropy.Content.Particles;
 using CalamityMod;
 using CalamityMod.Items;
+using CalamityMod.Buffs.DamageOverTime;
 using CalamityMod.Items.Materials;
 using CalamityMod.Rarities;
 using Microsoft.Xna.Framework.Graphics;
@@ -23,7 +24,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Depletion
         {
             Item.width = 62;
             Item.height = 62;
-            Item.damage = 45;
+            Item.damage = 35;
             Item.noMelee = true;
             Item.useAnimation = Item.useTime = 4;
             Item.useStyle = ItemUseStyleID.Shoot;
@@ -355,6 +356,11 @@ namespace CalamityEntropy.Content.Items.Weapons.Depletion
             modifiers.ArmorPenetration += 60;
             target.Entropy().Decrease20DR = 80;
         }
+        public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
+        {
+            target.AddBuff(ModContent.BuffType<VermillionFlux>(), 150);
+            target.AddBuff(ModContent.BuffType<HolyFlames>(), 150);
+        }
         public override void OnKill(int timeLeft)
         {
             CEUtils.PlaySound("light_bolt", Main.rand.NextFloat(2.4f, 2.8f), Projectile.Center, 50, 0.4f);
@@ -380,5 +386,4 @@ namespace CalamityEntropy.Content.Items.Weapons.Depletion
             }
         }
     }
-
 }

--- a/Content/Items/Weapons/Fractal/AbyssFractal.cs
+++ b/Content/Items/Weapons/Fractal/AbyssFractal.cs
@@ -20,7 +20,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Fractal
     {
         public override void SetDefaults()
         {
-            Item.damage = 86;
+            Item.damage = 80;
             Item.crit = 7;
             Item.DamageType = DamageClass.Melee;
             Item.width = 60;
@@ -36,7 +36,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Fractal
             Item.autoReuse = true;
             Item.shoot = ModContent.ProjectileType<AbyssFractalHeld>();
             Item.shootSpeed = 12f;
-            Item.ArmorPenetration = 20;
+            Item.ArmorPenetration = 15;
         }
         public int atkType = 1;
         public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)

--- a/Content/Items/Weapons/Fractal/BrilliantFractal.cs
+++ b/Content/Items/Weapons/Fractal/BrilliantFractal.cs
@@ -17,7 +17,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Fractal
     {
         public override void SetDefaults()
         {
-            Item.damage = 70;
+            Item.damage = 65;
             Item.crit = 5;
             Item.DamageType = DamageClass.Melee;
             Item.width = 48;
@@ -33,7 +33,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Fractal
             Item.autoReuse = true;
             Item.shoot = ModContent.ProjectileType<BrilliantFractalHeld>();
             Item.shootSpeed = 12f;
-            Item.ArmorPenetration = 15;
+            Item.ArmorPenetration = 5;
         }
         public int atkType = 1;
         public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)

--- a/Content/Items/Weapons/Fractal/BrokenHilt.cs
+++ b/Content/Items/Weapons/Fractal/BrokenHilt.cs
@@ -14,7 +14,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Fractal
     {
         public override void SetDefaults()
         {
-            Item.damage = 15;
+            Item.damage = 18;
             Item.DamageType = ModContent.GetInstance<TrueMeleeDamageClass>();
             Item.width = 48;
             Item.height = 60;

--- a/Content/Items/Weapons/Fractal/ElementalFractal.cs
+++ b/Content/Items/Weapons/Fractal/ElementalFractal.cs
@@ -19,7 +19,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Fractal
     {
         public override void SetDefaults()
         {
-            Item.damage = 520;
+            Item.damage = 480;
             Item.crit = 10;
             Item.DamageType = DamageClass.Melee;
             Item.width = 60;

--- a/Content/Items/Weapons/Fractal/ShatteredFractal.cs
+++ b/Content/Items/Weapons/Fractal/ShatteredFractal.cs
@@ -1,4 +1,4 @@
-﻿using CalamityEntropy.Content.Projectiles;
+using CalamityEntropy.Content.Projectiles;
 using CalamityMod;
 using CalamityMod.Items;
 using CalamityMod.Items.Weapons.Melee;
@@ -17,7 +17,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Fractal
     {
         public override void SetDefaults()
         {
-            Item.damage = 35;
+            Item.damage = 25;
             Item.DamageType = DamageClass.Melee;
             Item.width = 48;
             Item.height = 60;
@@ -151,7 +151,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Fractal
                     shoot = false;
                     if (Main.myPlayer == Projectile.owner)
                     {
-                        Projectile.NewProjectile(Projectile.GetSource_FromThis(), Projectile.Center + Projectile.velocity.normalize() * 100 * Projectile.scale, Projectile.velocity.normalize() * 10, ModContent.ProjectileType<FractalShoot>(), Projectile.damage, Projectile.knockBack, Projectile.owner);
+                        Projectile.NewProjectile(Projectile.GetSource_FromThis(), Projectile.Center + Projectile.velocity.normalize() * 100 * Projectile.scale, Projectile.velocity.normalize() * 10, ModContent.ProjectileType<FractalShoot>(), (int)(Projectile.damage * 1.5f), Projectile.knockBack, Projectile.owner);
                     }
                     CEUtils.PlaySound("sf_shoot", 1, Projectile.Center, volume: CEUtils.WeapSound);
                 }
@@ -259,5 +259,4 @@ namespace CalamityEntropy.Content.Items.Weapons.Fractal
             Utils.PlotTileLine(Projectile.Center, Projectile.Center + Projectile.rotation.ToRotationVector2() * (86 * (Projectile.ai[0] == 2 ? 1.24f : 1)) * Projectile.scale * scale, 84, DelegateMethods.CutTiles);
         }
     }
-
 }

--- a/Content/Items/Weapons/Fractal/StarlitFractal.cs
+++ b/Content/Items/Weapons/Fractal/StarlitFractal.cs
@@ -23,7 +23,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Fractal
     {
         public override void SetDefaults()
         {
-            Item.damage = 92;
+            Item.damage = 85;
             Item.crit = 7;
             Item.DamageType = DamageClass.Melee;
             Item.width = 48;
@@ -116,7 +116,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Fractal
                 {
                     int dir = (int)(Projectile.ai[0]) * (Projectile.velocity.X > 0 ? -1 : 1);
                     spawnProj = false;
-                    Projectile.NewProjectile(Projectile.GetSource_FromAI(), Projectile.Center + Projectile.rotation.ToRotationVector2() * 49, (Vector2)(CEUtils.normalize(Projectile.velocity.RotatedBy(dir * MathHelper.PiOver2)) * 3 + CEUtils.randomPointInCircle(2)), ModContent.ProjectileType<FractalStarBlade>(), (int)(Projectile.damage * 0.82f), Projectile.knockBack * 4, Projectile.owner, Projectile.rotation, dir);
+                    Projectile.NewProjectile(Projectile.GetSource_FromAI(), Projectile.Center + Projectile.rotation.ToRotationVector2() * 49, (Vector2)(CEUtils.normalize(Projectile.velocity.RotatedBy(dir * MathHelper.PiOver2)) * 3 + CEUtils.randomPointInCircle(2)), ModContent.ProjectileType<FractalStarBlade>(), (int)(Projectile.damage * 0.925f), Projectile.knockBack * 4, Projectile.owner, Projectile.rotation, dir);
                 }
             }
             if (init)

--- a/Content/Items/Weapons/Fractal/WelkinFractal.cs
+++ b/Content/Items/Weapons/Fractal/WelkinFractal.cs
@@ -1,6 +1,7 @@
-﻿using CalamityEntropy.Content.Projectiles;
+using CalamityEntropy.Content.Projectiles;
 using CalamityMod;
 using CalamityMod.Items;
+using CalamityMod.Buffs.DamageOverTime;
 using CalamityMod.Items.Weapons.Melee;
 using Microsoft.Xna.Framework.Graphics;
 using System;
@@ -17,7 +18,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Fractal
     {
         public override void SetDefaults()
         {
-            Item.damage = 42;
+            Item.damage = 36;
             Item.crit = 4;
             Item.DamageType = DamageClass.Melee;
             Item.width = 48;
@@ -52,10 +53,8 @@ namespace CalamityEntropy.Content.Items.Weapons.Fractal
         }
         public override void AddRecipes()
         {
-            CreateRecipe().AddIngredient<ShatteredFractal>()
-                .AddIngredient<CalamityMod.Items.Materials.AerialiteBar>(6)
-                .AddIngredient(ItemID.Feather, 2)
-                .AddIngredient(ItemID.SunplateBlock, 4)
+            CreateRecipe()
+		        .AddIngredient<ShatteredFractal>()
                 .AddIngredient(ItemID.Starfury)
                 .AddIngredient<WindBlade>()
                 .AddTile(TileID.Anvils)
@@ -191,6 +190,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Fractal
         public bool playHitSound = true;
         public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
         {
+	        target.AddBuff(ModContent.BuffType<WindChilled>(), 300);
             if (playHitSound)
             {
                 playHitSound = false;

--- a/Content/Items/Weapons/GrassSword/Bramblecleave.cs
+++ b/Content/Items/Weapons/GrassSword/Bramblecleave.cs
@@ -165,21 +165,21 @@ namespace CalamityEntropy.Content.Items.Weapons.GrassSword
                 int dmg = Item.damage;
                 switch (level)
                 {
-                    case 0: dmg = 10; break;
+                    case 0: dmg = 12; break;
                     case 1: dmg = 18; break;
                     case 2: dmg = 24; break;
                     case 3: dmg = 28; break;
-                    case 4: dmg = 35; break;
+                    case 4: dmg = 36; break;
                     case 5: dmg = 80; break;
-                    case 6: dmg = 95; break;
+                    case 6: dmg = 100; break;
                     case 7: dmg = 120; break;
                     case 8: dmg = 140; break;
                     case 9: dmg = 150; break;
                     case 10: dmg = 480; break;
                     case 11: dmg = 600; break;
-                    case 12: dmg = 1200; break;
-                    case 13: dmg = 1350; break;
-                    case 14: dmg = 1500; break;
+                    case 12: dmg = 1250; break;
+                    case 13: dmg = 1400; break;
+                    case 14: dmg = 1600; break;
                     case 15: dmg = 3600; break;
                 }
                 Item.damage = dmg;

--- a/Content/Items/Weapons/GrassSword/Bramblecleave.cs
+++ b/Content/Items/Weapons/GrassSword/Bramblecleave.cs
@@ -23,7 +23,7 @@ namespace CalamityEntropy.Content.Items.Weapons.GrassSword
         }
         public override void SetDefaults()
         {
-            Item.damage = 20;
+            Item.damage = 10;
             Item.DamageType = ModContent.GetInstance<TrueMeleeDamageClass>();
             Item.width = 48;
             Item.height = 60;
@@ -165,21 +165,21 @@ namespace CalamityEntropy.Content.Items.Weapons.GrassSword
                 int dmg = Item.damage;
                 switch (level)
                 {
-                    case 0: dmg = 20; break;
-                    case 1: dmg = 30; break;
-                    case 2: dmg = 36; break;
-                    case 3: dmg = 45; break;
-                    case 4: dmg = 55; break;
-                    case 5: dmg = 100; break;
-                    case 6: dmg = 110; break;
-                    case 7: dmg = 150; break;
-                    case 8: dmg = 170; break;
-                    case 9: dmg = 195; break;
+                    case 0: dmg = 10; break;
+                    case 1: dmg = 18; break;
+                    case 2: dmg = 24; break;
+                    case 3: dmg = 28; break;
+                    case 4: dmg = 35; break;
+                    case 5: dmg = 80; break;
+                    case 6: dmg = 95; break;
+                    case 7: dmg = 120; break;
+                    case 8: dmg = 140; break;
+                    case 9: dmg = 150; break;
                     case 10: dmg = 480; break;
-                    case 11: dmg = 720; break;
-                    case 12: dmg = 1400; break;
-                    case 13: dmg = 1800; break;
-                    case 14: dmg = 2000; break;
+                    case 11: dmg = 600; break;
+                    case 12: dmg = 1200; break;
+                    case 13: dmg = 1350; break;
+                    case 14: dmg = 1500; break;
                     case 15: dmg = 3600; break;
                 }
                 Item.damage = dmg;
@@ -364,7 +364,7 @@ namespace CalamityEntropy.Content.Items.Weapons.GrassSword
             if (init)
             {
                 CEUtils.PlaySound("powerwhip", Projectile.ai[2] == 0 ? 1.75f / Projectile.ai[1] : 0.6f, Projectile.Center);
-                Projectile.scale = 1.6f + 0.1f * Bramblecleave.GetLevel();
+                Projectile.scale = 1.25f + 0.1f * Bramblecleave.GetLevel();
                 float scale_ = owner.HeldItem.scale;
                 owner.ApplyMeleeScale(ref scale_);
                 Projectile.scale *= scale_;
@@ -473,7 +473,7 @@ namespace CalamityEntropy.Content.Items.Weapons.GrassSword
 
                             if (Spin)
                             {
-                                Projectile.NewProjectile(Projectile.GetSource_FromAI(), Projectile.Center, Projectile.velocity, ModContent.ProjectileType<BramblecleaveAlt>(), (int)(Projectile.damage * 0.5f), 0, Projectile.owner);
+                                Projectile.NewProjectile(Projectile.GetSource_FromAI(), Projectile.Center, Projectile.velocity, ModContent.ProjectileType<BramblecleaveAlt>(), (int)(Projectile.damage * 0.66f), 0, Projectile.owner);
                             }
                             else
                             {

--- a/Content/Items/Weapons/GreatSwordofEmbers.cs
+++ b/Content/Items/Weapons/GreatSwordofEmbers.cs
@@ -21,7 +21,7 @@ namespace CalamityEntropy.Content.Items.Weapons
         public int ProjectileType => Item.shoot;
         public override void SetDefaults()
         {
-            Item.damage = 142;
+            Item.damage = 150;
             Item.DamageType = ModContent.GetInstance<TrueMeleeDamageClass>();
             Item.width = 70;
             Item.height = 72;

--- a/Content/Items/Weapons/MoonlightSword.cs
+++ b/Content/Items/Weapons/MoonlightSword.cs
@@ -1,4 +1,4 @@
-﻿using CalamityEntropy.Content.Particles;
+using CalamityEntropy.Content.Particles;
 using CalamityMod;
 using CalamityMod.Items;
 using CalamityMod.Items.Materials;
@@ -17,7 +17,7 @@ namespace CalamityEntropy.Content.Items.Weapons
     {
         public override void SetDefaults()
         {
-            Item.damage = 62;
+            Item.damage = 40;
             Item.DamageType = ModContent.GetInstance<MeleeDamageClass>();
             Item.width = 48;
             Item.height = 60;
@@ -114,7 +114,7 @@ namespace CalamityEntropy.Content.Items.Weapons
 
                 if (!Projectile.GetOwner().Calamity().bladeArmEnchant && Main.myPlayer == Projectile.owner)
                 {
-                    Projectile.NewProjectile(Projectile.GetSource_FromAI(), Projectile.Center, Projectile.velocity * 2, ModContent.ProjectileType<MoonlightShoot>(), Projectile.damage, Projectile.knockBack / 2, Projectile.owner);
+                    Projectile.NewProjectile(Projectile.GetSource_FromAI(), Projectile.Center, Projectile.velocity * 2, ModContent.ProjectileType<MoonlightShoot>(), (int)(Projectile.damage * 1.3f), Projectile.knockBack / 2, Projectile.owner);
                 }
             }
             odr.Add(Projectile.rotation);

--- a/Content/Items/Weapons/Revelation.cs
+++ b/Content/Items/Weapons/Revelation.cs
@@ -1,4 +1,4 @@
-﻿using CalamityEntropy.Content.Projectiles;
+using CalamityEntropy.Content.Projectiles;
 using CalamityMod;
 using CalamityMod.Items;
 using CalamityMod.Items.Materials;
@@ -63,9 +63,8 @@ namespace CalamityEntropy.Content.Items.Weapons
         public override void AddRecipes()
         {
             Recipe recipe = CreateRecipe();
-            recipe.AddIngredient(ModContent.ItemType<MeldBlob>(), 5);
-            recipe.AddIngredient(ModContent.ItemType<ShardofAntumbra>(), 1);
-            recipe.AddIngredient(ItemID.DeathSickle, 1);
+            recipe.AddIngredient(ModContent.ItemType<SubductionSlicer>(), 1);
+	        recipe.AddIngredient(ModContent.ItemType<MeldBlob>(), 12);
             recipe.AddTile(TileID.LunarCraftingStation);
             recipe.Register();
         }

--- a/Content/Items/Weapons/RuneSong.cs
+++ b/Content/Items/Weapons/RuneSong.cs
@@ -10,7 +10,7 @@ namespace CalamityEntropy.Content.Items.Weapons
     {
         public override void SetDefaults()
         {
-            Item.damage = 132;
+            Item.damage = 100;
             Item.DamageType = DamageClass.Melee;
             Item.width = 56;
             Item.noUseGraphic = true;

--- a/Content/Items/Weapons/VoidBlade.cs
+++ b/Content/Items/Weapons/VoidBlade.cs
@@ -11,8 +11,8 @@ namespace CalamityEntropy.Content.Items.Weapons
     {
         public override void SetDefaults()
         {
-            Item.damage = 56;
-            Item.crit = 4;
+            Item.damage = 40;
+            Item.crit = 15;
             Item.DamageType = ModContent.GetInstance<TrueMeleeDamageClass>();
             Item.width = 100;
             Item.noUseGraphic = true;

--- a/Content/NPCs/PrimordialWyrmNPC.cs
+++ b/Content/NPCs/PrimordialWyrmNPC.cs
@@ -1,4 +1,4 @@
-﻿using CalamityEntropy.Content.Buffs;
+using CalamityEntropy.Content.Buffs;
 using CalamityEntropy.Content.Items;
 using CalamityEntropy.Content.Projectiles;
 using CalamityMod;
@@ -8,7 +8,10 @@ using CalamityMod.Items.Placeables;
 using CalamityMod.Items.TreasureBags.MiscGrabBags;
 using CalamityMod.Items.Weapons.Magic;
 using CalamityMod.Items.Weapons.Melee;
+using CalamityMod.Items.Weapons.Summon;
 using CalamityMod.Items.Weapons.Ranged;
+using CalamityMod.Items.Weapons.Rogue;
+using CalamityMod.Items.Tools;
 using CalamityMod.NPCs.PrimordialWyrm;
 using CalamityMod.Projectiles.Magic;
 using CalamityMod.Sounds;
@@ -163,8 +166,11 @@ namespace CalamityEntropy.Content.NPCs
         public override void AddShops()
         {
             var npcShop = new NPCShop(Type, ShopName)
+		        .Add<CalamarisLament>()
+		        .Add<Valediction>()
+		        .Add<DeepSeaDumbbell>()
+		        .Add<GrandDad>()
                 .Add<EidolicWail>()
-                .Add<VoidEdge>()
                 .Add<EidolonStaff>()
                 .Add<HalibutCannon>()
                 .Add<Lumenyl>()
@@ -173,6 +179,8 @@ namespace CalamityEntropy.Content.NPCs
                 .Add<AbyssalTreasure>()
                 .Add<VoidTorch>()
                 .Add<AbyssShellFossil>()
+		        .Add<BobbitHook>()
+		        .Add<ReaperTooth>()
                 .Add<WyrmTooth>()
                 .Add<Rock>(new Condition(Mod.GetLocalization("PassedBossRush"), () => DownedBossSystem.downedBossRush))
                 .Add(ModLoader.GetMod("CalamityModMusic").Find<ModItem>("PrimordialWyrmMusicBox").Type);

--- a/Content/Projectiles/VoidBlade/VoidBladeHit.cs
+++ b/Content/Projectiles/VoidBlade/VoidBladeHit.cs
@@ -30,7 +30,7 @@ namespace CalamityEntropy.Content.Projectiles.VoidBlade
             Projectile.penetrate = -1;
             Projectile.tileCollide = false;
             Projectile.light = 1f;
-            Projectile.scale = 1.6f;
+            Projectile.scale = 1.2f;
             Projectile.damage = 0;
             Projectile.timeLeft = 20;
             var r = Main.rand;

--- a/Content/Projectiles/VoidBlade/VoidBladeProj.cs
+++ b/Content/Projectiles/VoidBlade/VoidBladeProj.cs
@@ -28,7 +28,7 @@ namespace CalamityEntropy.Content.Projectiles.VoidBlade
             Projectile.penetrate = -1;
             Projectile.tileCollide = false;
             Projectile.light = 0f;
-            Projectile.scale = 1.6f;
+            Projectile.scale = 1.2f;
             Projectile.usesLocalNPCImmunity = true;
             Projectile.localNPCHitCooldown = 0;
         }

--- a/Content/Projectiles/WindOfUndertakerProjectile.cs
+++ b/Content/Projectiles/WindOfUndertakerProjectile.cs
@@ -79,7 +79,7 @@ namespace CalamityEntropy.Content.Projectiles
         {
             EGlobalNPC.RemoveAllTags(target);
             target.AddBuff(ModContent.BuffType<CruiserWhipDebuff>(), 240);
-            target.AddBuff(ModContent.BuffType<MarkedforDeath>(), 150);
+            target.AddBuff(ModContent.BuffType<ArmorCrunch>(), 150);
             Main.player[Projectile.owner].MinionAttackTargetNPC = target.whoAmI;
             Projectile.damage = (int)(Projectile.damage * 0.9f);
 

--- a/Content/Projectiles/YstralynProj.cs
+++ b/Content/Projectiles/YstralynProj.cs
@@ -70,7 +70,7 @@ namespace CalamityEntropy.Content.Projectiles
             var player = Projectile.GetOwner();
             player.AddBuff(ModContent.BuffType<WyrmPhantom>(), 480);
             target.AddBuff(ModContent.BuffType<WyrmWhipDebuff>(), 380);
-            target.AddBuff(ModContent.BuffType<MarkedforDeath>(), 600);
+            target.AddBuff(ModContent.BuffType<ArmorCrunch>(), 600);
             Main.player[Projectile.owner].MinionAttackTargetNPC = target.whoAmI;
             CEUtils.PlaySound("ystn_hit", Main.rand.NextFloat(0.86f, 1.2f), target.Center, 3, 0.76f);
             for (int ii = 0; ii < 4; ii++)


### PR DESCRIPTION
1.埋葬之阳，配方修改为18个冥思构造体，与常规冥思武器一致，面板提升至120
2.福音，面板降低至230，对标月炎之锋，奴役之星，面板降低至70，对标全能之刃
3.启示录，配方修改为板块斩切者+12个冥思构造体，防止出现用冥思武器做冥思武器的尴尬局面
4.符文之歌，面板降低至100，使得其实战强度不会超过星熠分形
5.虚空锋刃，面板降低至40，暴击率提升至15，射弹大小缩小20%使得其略大于鬼妖村正，对标同时期炎灼热巨剑，而不是能五十秒砍死毁灭者的肉后武器
6.灼炎巨剑，面板提升至150
7.反虚之锋，面板降低至325，使其成为银河的可替代上位（1.5倍差距）
8.月光巨剑，面板降低至40但是射弹倍率提升至130%，防止其超越烬甲魔武器
9.新版本死亡标记大幅削弱，无法降低免伤，将巡游鞭和妖龙鞭的死亡标记效果换成护甲撕裂
10.王冠蓝宝石圈内的加成降低至1回血4免伤8伤害
11.灾灵，面板降低至35，现在会造成3秒的赤羽流霆和神圣之火，在天神大幅加强的前提下依然强势，能够与时期更靠后的强力武器雷霆意志相媲美
12.苍蓝刺剑，伤害类型修改为真近战伤害，符合真近战特性
13.妖龙npc现在会售卖雄祖之护而非虚渊之锋，同时会售卖其他深渊四层特有的掉落材料，降低玩家肝度，同时防止一些炼狱出深渊bug的玩家毕业无法做妖龙盔甲
14.与玛门的污秽契约，面板降低至225，使其在白嫖献奉下，对标666面板的老怨戾，同时给予500点启动蓝量消耗，使得其他职业无法使用该武器。
15.提升苍郁之锋的右键倍率，重新调整全流程面板，略微降低了初始大小，使其与灾熵的全流程真近战强度相匹配而不是全局碾压，让其他武器有出场的机会
16.分形：
破碎剑柄面板提升至18，对标二级矿阔剑
破碎分形面板降低至25，但是射弹倍率提升至150%，加强其远程能力，对标永夜刃
苍穹分形面板降低至36，去除配方中的羽毛，天蓝锭等杂项，现在能造成天蓝系列的风寒减益，使其强度略低于灰烬之刃
光辉分形面板降低至65，穿甲层数降低至5，考虑到新版本肉初boss大幅削弱，武器强度要求降低，对标环境之刃纯净调谐
深渊分形面板降低至80，穿甲层数降低至15，对标花后两月的强力武器如雪人炮和链式机枪
星熠分形面板降低至85，但是剑影倍率提升至92.5%，将部分近战伤害转移至远程射弹上，强化风筝打月的水平
元素分形面板降低至480，在天神战对标同时期召唤师