### PR TITLE
抽奖机翻新

### DIFF
--- a/Content/Items/Books/AshTranscript.cs
+++ b/Content/Items/Books/AshTranscript.cs
@@ -16,7 +16,7 @@ namespace CalamityEntropy.Content.Items.Books
         public override void SetDefaults()
         {
             base.SetDefaults();
-            Item.damage = 162;
+            Item.damage = 140;
             Item.useAnimation = Item.useTime = 25;
             Item.crit = 10;
             Item.mana = 20;

--- a/Content/Items/Weapons/Fractal/VoidFractal.cs
+++ b/Content/Items/Weapons/Fractal/VoidFractal.cs
@@ -181,7 +181,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Fractal
                     Vector2 spawnPos = Projectile.Center + Projectile.rotation.ToRotationVector2() * 48 * scale * Projectile.scale;
                     if (Main.myPlayer == Projectile.owner && !noProj)
                     {
-                        Projectile.NewProjectile(Projectile.GetSource_FromAI(), spawnPos, CEUtils.randomPointInCircle(0.1f) + Projectile.rotation.ToRotationVector2() * 8, ModContent.ProjectileType<VoidStarF>(), Projectile.damage / 8, Projectile.knockBack, Projectile.owner).ToProj().DamageType = DamageClass.Melee;
+                        Projectile.NewProjectile(Projectile.GetSource_FromAI(), spawnPos, CEUtils.randomPointInCircle(0.1f) + Projectile.rotation.ToRotationVector2() * 8, ModContent.ProjectileType<VoidStarF>(), Projectile.damage / 3, Projectile.knockBack, Projectile.owner).ToProj().DamageType = DamageClass.Melee;
                     }
                 }
                 alpha = 1;
@@ -231,7 +231,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Fractal
                     if (progress > 0.2f && shoot)
                     {
                         shoot = false;
-                        Projectile.NewProjectile(Projectile.GetSource_FromThis(), Projectile.Center, (Vector2)(CEUtils.normalize(Projectile.velocity) * 12 + CEUtils.randomPointInCircle(6)), ModContent.ProjectileType<VoidWave>(), Projectile.damage * 2, Projectile.knockBack, Projectile.owner);
+                        Projectile.NewProjectile(Projectile.GetSource_FromThis(), Projectile.Center, (Vector2)(CEUtils.normalize(Projectile.velocity) * 12 + CEUtils.randomPointInCircle(6)), ModContent.ProjectileType<VoidWave>(), Projectile.damage * 1, Projectile.knockBack, Projectile.owner);
                     }
                     if (progress < 0.6f)
                     {

--- a/Content/NPCs/Cruiser/CruiserHead.cs
+++ b/Content/NPCs/Cruiser/CruiserHead.cs
@@ -178,10 +178,8 @@ namespace CalamityEntropy.Content.NPCs.Cruiser
             }
             if (Main.getGoodWorld)
             {
-                NPC.scale = 1.5f;
-                length += 46;
+                NPC.scale = 1.33f;
                 NPC.lifeMax += 750000;
-                NPC.defense += 40;
             }
             if (Main.zenithWorld)
             {

--- a/Content/NPCs/FriendFinderNPC/AeroSlimeFriendly.cs
+++ b/Content/NPCs/FriendFinderNPC/AeroSlimeFriendly.cs
@@ -18,10 +18,10 @@ namespace CalamityEntropy.Content.NPCs.FriendFinderNPC
         public override void SetDefaults()
         {
             NPC.noTileCollide = true;
-            NPC.damage = 48;
+            NPC.damage = 25;
             NPC.width = 40;
             NPC.height = 30;
-            NPC.defense = 6;
+            NPC.defense = 15;
             NPC.lifeMax = 500;
             NPC.knockBackResist = 0.8f;
             AnimationType = NPCID.Slimer;

--- a/Content/NPCs/FriendFinderNPC/DespairStoneFriendly.cs
+++ b/Content/NPCs/FriendFinderNPC/DespairStoneFriendly.cs
@@ -27,7 +27,7 @@ namespace CalamityEntropy.Content.NPCs.FriendFinderNPC
         {
             NPC.aiStyle = -1;
             AIType = -1;
-            NPC.damage = 100;
+            NPC.damage = 80;
             NPC.width = 72;
             NPC.height = 72;
             NPC.defense = 38;

--- a/Content/NPCs/FriendFinderNPC/IceClasperFriendly.cs
+++ b/Content/NPCs/FriendFinderNPC/IceClasperFriendly.cs
@@ -69,7 +69,7 @@ namespace CalamityEntropy.Content.NPCs.FriendFinderNPC
         {
             NPC.npcSlots = 3f;
             NPC.noGravity = true;
-            NPC.damage = 62;
+            NPC.damage = 35;
             NPC.width = 50;
             NPC.height = 50;
             NPC.defense = 12;

--- a/Content/NPCs/FriendFinderNPC/ScryllarFriendly.cs
+++ b/Content/NPCs/FriendFinderNPC/ScryllarFriendly.cs
@@ -21,7 +21,7 @@ namespace CalamityEntropy.Content.NPCs.FriendFinderNPC
         {
             NPC.aiStyle = -1;
             AIType = -1;
-            NPC.damage = 24;
+            NPC.damage = 12;
             NPC.width = 80;
             NPC.height = 80;
             NPC.defense = 18;

--- a/Content/NPCs/FriendFinderNPC/SkyfinFriendly.cs
+++ b/Content/NPCs/FriendFinderNPC/SkyfinFriendly.cs
@@ -30,9 +30,9 @@ namespace CalamityEntropy.Content.NPCs.FriendFinderNPC
             NPC.height = 22;
             NPC.aiStyle = AIType = -1;
 
-            NPC.damage = 80;
+            NPC.damage = 60;
             NPC.lifeMax = 500;
-            NPC.defense = 8;
+            NPC.defense = 15;
             NPC.knockBackResist = 0.3f;
 
 

--- a/Content/NPCs/FriendFinderNPC/SoulSlurperFriendly.cs
+++ b/Content/NPCs/FriendFinderNPC/SoulSlurperFriendly.cs
@@ -32,7 +32,7 @@ namespace CalamityEntropy.Content.NPCs.FriendFinderNPC
             NPC.aiStyle = -1;
             AIType = -1;
             NPC.npcSlots = 1f;
-            NPC.damage = 60;
+            NPC.damage = 35;
             NPC.width = 40;
             NPC.height = 40;
             NPC.defense = 30;

--- a/Content/NPCs/LotteryMachine.cs
+++ b/Content/NPCs/LotteryMachine.cs
@@ -1,4 +1,4 @@
-﻿using CalamityEntropy.Content.Items;
+using CalamityEntropy.Content.Items;
 using CalamityEntropy.Content.Items.Weapons;
 using CalamityEntropy.Content.Particles;
 using CalamityEntropy.Content.Projectiles;
@@ -97,8 +97,12 @@ namespace CalamityEntropy.Content.NPCs
         public RewardPool p1;
         public RewardPool g2;
         public RewardPool p2;
+        public RewardPool g3;
         public RewardPool p3;
         public RewardPool p4;
+        public RewardPool p5;
+        public RewardPool p6;
+        public RewardPool p7;
         public bool sd = true;
         public bool say = false;
         public Color sayColor = Color.White;
@@ -332,102 +336,154 @@ namespace CalamityEntropy.Content.NPCs
 
                 g1 = new RewardPool();
                 g1.Add(new RewardPoolItem(ModContent.ItemType<SulphuricScale>(), 1)); g1.Add(new RewardPoolItem(1320, 1));
-                g1.Add(new RewardPoolItem(ModContent.ItemType<AncientBoneDust>(), 2));
                 g1.Add(new RewardPoolItem(ItemID.LifeCrystal, 4));
                 g1.Add(new RewardPoolItem(ModContent.ItemType<AshenStalactite>(), 1));
                 g1.Add(new RewardPoolItem(ModContent.ItemType<RottenDogtooth>(), 1));
-                g1.Add(new RewardPoolItem(ModContent.ItemType<AncientBoneDust>(), 2)); s1.Add(new RewardPoolItem(ItemID.PoopBlock, 50));
-                g1.Add(new RewardPoolItem(0, 1));
+                g1.Add(new RewardPoolItem(ModContent.ItemType<AnechoicCoating>(), 5)); g1.Add(new RewardPoolItem(1303, 1));
+                g1.Add(new RewardPoolItem(1322, 1));
                 g1.Add(new RewardPoolItem(ItemID.HealingPotion, 10));
                 g1.Add(new RewardPoolItem(ItemID.HeartLantern, 1));
                 g1.Add(new RewardPoolItem(ItemID.ManaPotion, 10));
-                g1.Add(new RewardPoolItem(ItemID.Ruby, 60));
-                g1.Add(new RewardPoolItem(ItemID.LifeCrystal, 4));
+                g1.Add(new RewardPoolItem(ItemID.Ruby, 15));
+                g1.Add(new RewardPoolItem(1128, 1));
 
                 p1 = new RewardPool();
                 p1.Add(new RewardPoolItem(2341, 1));
                 p1.Add(new RewardPoolItem(906, 1));
                 p1.Add(new RewardPoolItem(ModContent.ItemType<OldLordClaymore>(), 1)); p1.Add(new RewardPoolItem(2296, 1));
-                p1.Add(new RewardPoolItem(ItemID.FallenStar, 300)); p1.Add(new RewardPoolItem(ModContent.ItemType<AeroStone>(), 1));
+                p1.Add(new RewardPoolItem(ItemID.FallenStar, 300)); p1.Add(new RewardPoolItem(ModContent.ItemType<GiantShell>(), 1));
                 p1.Add(new RewardPoolItem(2430, 1));
-                p1.Add(new RewardPoolItem(ModContent.ItemType<AncientBoneDust>(), 2));
+                p1.Add(new RewardPoolItem(ModContent.ItemType<BurntSienna>(), 2));
                 p1.Add(new RewardPoolItem(ItemID.HealingPotion, 100));
                 p1.Add(new RewardPoolItem(ItemID.ManaPotion, 100));
                 p1.Add(new RewardPoolItem(ModContent.ItemType<CrownJewel>(), 1));
                 p1.Add(new RewardPoolItem(ModContent.ItemType<RustyBeaconPrototype>(), 1));
-                p1.Add(new RewardPoolItem(ItemID.LifeCrystal, 10));
+                p1.Add(new RewardPoolItem(ItemID.LifeCrystal, 8));
 
                 g2 = new RewardPool();
                 g2.Add(new RewardPoolItem(ModContent.ItemType<TitanHeart>(), 3));
                 g2.Add(new RewardPoolItem(ModContent.ItemType<UrsaSergeant>(), 1));
                 g2.Add(new RewardPoolItem(ModContent.ItemType<SolarVeil>(), 2));
-                g2.Add(new RewardPoolItem(ModContent.ItemType<AshesofCalamity>(), 1));
-                g2.Add(new RewardPoolItem(1508, 3));
-                g2.Add(new RewardPoolItem(391, 15));
-                g2.Add(new RewardPoolItem(1198, 15));
+                g2.Add(new RewardPoolItem(ModContent.ItemType<Poseidon>(), 1));
+                g2.Add(new RewardPoolItem(1518, 1));
+                g2.Add(new RewardPoolItem(381, 15));
+                g2.Add(new RewardPoolItem(1184, 15));
                 g2.Add(new RewardPoolItem(1612, 1));
-                g2.Add(new RewardPoolItem(ModContent.ItemType<GrandScale>(), 1));
-                g2.Add(new RewardPoolItem(ModContent.ItemType<GravityNormalizerPotion>(), 1));
+                g2.Add(new RewardPoolItem(ModContent.ItemType<IcicleTrident>(), 1));
+                g2.Add(new RewardPoolItem(ModContent.ItemType<ElephantKiller>(), 1));
                 g2.Add(new RewardPoolItem(ModContent.ItemType<Abaddon>(), 1));
-                g2.Add(new RewardPoolItem(ModContent.ItemType<AncientBoneDust>(), 2));
+                g2.Add(new RewardPoolItem(ModContent.ItemType<CelestialClaymore>(), 1));
                 g2.Add(new RewardPoolItem(ModContent.ItemType<YharimsStimulants>(), 6));
 
                 p2 = new RewardPool();
-                p2.Add(new RewardPoolItem(3456, 10));
-                p2.Add(new RewardPoolItem(3457, 10));
-                p2.Add(new RewardPoolItem(3458, 10));
-                p2.Add(new RewardPoolItem(3459, 10));
-                p2.Add(new RewardPoolItem(ModContent.ItemType<MeldBlob>(), 1));
-                p2.Add(new RewardPoolItem(ModContent.ItemType<EffulgentFeather>(), 1));
+                p2.Add(new RewardPoolItem(1291, 5));
+                p2.Add(new RewardPoolItem(365, 15));
+                p2.Add(new RewardPoolItem(1105, 15));
+                p2.Add(new RewardPoolItem(1253, 10));
+                p2.Add(new RewardPoolItem(ModContent.ItemType<StormSaber>(), 1));
+                p2.Add(new RewardPoolItem(ModContent.ItemType<FrigidflashBolt>(), 1));
                 p2.Add(new RewardPoolItem(ModContent.ItemType<TheFirstShadowflame>(), 1));
-                p2.Add(new RewardPoolItem(ModContent.ItemType<Baroclaw>(), 1));
-                p2.Add(new RewardPoolItem(ModContent.ItemType<InfectedJewel>(), 1));
+                p2.Add(new RewardPoolItem(ModContent.ItemType<IgneousExaltation>(), 1));
+                p2.Add(new RewardPoolItem(ModContent.ItemType<IceStar>(), 1));
                 p2.Add(new RewardPoolItem(ModContent.ItemType<CryonicBar>(), 3));
-                p2.Add(new RewardPoolItem(ModContent.ItemType<TheCamper>(), 1));
-                p2.Add(new RewardPoolItem(ModContent.ItemType<SHPC>(), 1));
+                p2.Add(new RewardPoolItem(ModContent.ItemType<RuinMedallion>(), 1));
+                p2.Add(new RewardPoolItem(ModContent.ItemType<BelchingSaxophone>(), 1));
                 p2.Add(new RewardPoolItem(ModContent.ItemType<TheDarkMaster>(), 1));
-                p2.Add(new RewardPoolItem(ModContent.ItemType<AncientBoneDust>(), 2));
-                p3 = new RewardPool();
+                p2.Add(new RewardPoolItem(ModContent.ItemType<SolarVeil>(), 2));
 
-                p3.Add(new RewardPoolItem(ModContent.ItemType<Necroplasm>(), 50));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<DarkPlasma>(), 1));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<ArkoftheElements>(), 1));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<ClockworkBow>(), 1));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<SanctifiedSpark>(), 1));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<AbyssalDivingSuit>(), 1));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<MirrorBlade>(), 1));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<Swordsplosion>(), 1));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<BurningRevelation>(), 1));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<ReaperTooth>(), 1));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<PlanetaryAnnihilation>(), 1));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<TwistingNether>(), 1));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<ArmoredShell>(), 1));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<OccultSkullCrown>(), 1));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<AncientBoneDust>(), 2));
-                p3 = new RewardPool();
+                g3 = new RewardPool();
+                g3.Add(new RewardPoolItem(ModContent.ItemType<HivePod>(), 1));
+                g3.Add(new RewardPoolItem(ModContent.ItemType<LivingShard>(), 10));
+                g3.Add(new RewardPoolItem(ModContent.ItemType<CoreofCalamity>(), 2));
+                g3.Add(new RewardPoolItem(1006, 30));
+                g3.Add(new RewardPoolItem(1551, 1));
+                g3.Add(new RewardPoolItem(3018, 1));
+                g3.Add(new RewardPoolItem(3021, 1));
+                g3.Add(new RewardPoolItem(ModContent.ItemType<TheCommunity>(), 1));
+                g3.Add(new RewardPoolItem(ModContent.ItemType<Regenerator>(), 1));
+                g3.Add(new RewardPoolItem(ModContent.ItemType<BloomStone>(), 1));
+                g3.Add(new RewardPoolItem(ModContent.ItemType<AbyssalDivingGear>(), 1));
 
-                p3.Add(new RewardPoolItem(ModContent.ItemType<Necroplasm>(), 30));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<AuricOre>(), 1));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<CosmicWorm>(), 1));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<SupremeHealingPotion>(), 3));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<EidolicWail>(), 1));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<PhosphorescentGauntlet>(), 1));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<Murasama>(), 1));
-                p3.Add(new RewardPoolItem(ItemID.LastPrism, 1));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<PristineFury>(), 1));
-                p3.Add(new RewardPoolItem(ModContent.ItemType<AncientBoneDust>(), 2));
+                p3 = new RewardPool();
+                p3.Add(new RewardPoolItem(938, 1));
+                p3.Add(new RewardPoolItem(1508, 15));
+                p3.Add(new RewardPoolItem(1513, 1));
+                p3.Add(new RewardPoolItem(1570, 1));
+                p3.Add(new RewardPoolItem(1552, 20));
+                p3.Add(new RewardPoolItem(3261, 20));
+                p3.Add(new RewardPoolItem(1444, 1));
+                p3.Add(new RewardPoolItem(1445, 1));
+                p3.Add(new RewardPoolItem(1446, 1));
+                p3.Add(new RewardPoolItem(4679, 1));
+                p3.Add(new RewardPoolItem(ModContent.ItemType<BlossomFlux>(), 1));
+                p3.Add(new RewardPoolItem(ModContent.ItemType<EternalBlizzard>(), 1));
+                p3.Add(new RewardPoolItem(ModContent.ItemType<Keelhaul>(), 1));
+                p3.Add(new RewardPoolItem(ModContent.ItemType<HadalUrn>(), 1));
+                p3.Add(new RewardPoolItem(ModContent.ItemType<FantasyTalisman>(), 1));
+                p3.Add(new RewardPoolItem(ModContent.ItemType<PerennialBar>(), 20));
+                p3.Add(new RewardPoolItem(ModContent.ItemType<GrandScale>(), 2));
 
                 p4 = new RewardPool();
-                p4.Add(new RewardPoolItem(ModContent.ItemType<PrisonOfPermafrost>(), 1));
-                p4.Add(new RewardPoolItem(ModContent.ItemType<CodebreakerBase>(), 1));
-                p4.Add(new RewardPoolItem(ModContent.ItemType<YharimsCrystal>(), 1));
-                p4.Add(new RewardPoolItem(ModContent.ItemType<AscendantSpiritEssence>(), 15));
-                p4.Add(new RewardPoolItem(ModContent.ItemType<AuricOre>(), 100));
-                p4.Add(new RewardPoolItem(ModContent.ItemType<Vehemence>(), 1));
-                p4.Add(new RewardPoolItem(ModContent.ItemType<Sacrifice>(), 1));
-                p4.Add(new RewardPoolItem(ModContent.ItemType<YharonSoulFragment>(), 15));
-                p4.Add(new RewardPoolItem(ModContent.ItemType<AuricBar>(), 10));
-                p4.Add(new RewardPoolItem(ItemID.Zenith, 1));
+                p4.Add(new RewardPoolItem(3110, 1));
+                p4.Add(new RewardPoolItem(1248, 1));
+                p4.Add(new RewardPoolItem(1343, 1));
+                p4.Add(new RewardPoolItem(1858, 1));
+                p4.Add(new RewardPoolItem(3883, 1));
+                p4.Add(new RewardPoolItem(3817, 80));
+                p4.Add(new RewardPoolItem(ModContent.ItemType<Malachite>(), 1));
+                p4.Add(new RewardPoolItem(ModContent.ItemType<LifeAlloy>(), 5));
+                p4.Add(new RewardPoolItem(ModContent.ItemType<PlagueCellCanister>(), 50));
+                p4.Add(new RewardPoolItem(ModContent.ItemType<ExaltedOathblade>(), 1));
+                p4.Add(new RewardPoolItem(ModContent.ItemType<TenebreusTides>(), 1));
+                p4.Add(new RewardPoolItem(ModContent.ItemType<ScoriaBar>(), 25));
+                p4.Add(new RewardPoolItem(ModContent.ItemType<AegisBlade>(), 1));
+                p4.Add(new RewardPoolItem(ModContent.ItemType<StarSputter>(), 1));
+                p4.Add(new RewardPoolItem(ModContent.ItemType<Vesuvius>(), 1));
+                p4.Add(new RewardPoolItem(ModContent.ItemType<BrinyBaron>(), 1));
+
+                p5 = new RewardPool();
+                p5.Add(new RewardPoolItem(ModContent.ItemType<Necroplasm>(), 40));
+                p5.Add(new RewardPoolItem(ModContent.ItemType<BloodstoneCore>(), 4));
+                p5.Add(new RewardPoolItem(ModContent.ItemType<ArkoftheElements>(), 1));
+                p5.Add(new RewardPoolItem(ModContent.ItemType<ClockworkBow>(), 1));
+                p5.Add(new RewardPoolItem(ModContent.ItemType<SanctifiedSpark>(), 1));
+                p5.Add(new RewardPoolItem(ModContent.ItemType<AbyssalDivingSuit>(), 1));
+                p5.Add(new RewardPoolItem(ModContent.ItemType<MirrorBlade>(), 1));
+                p5.Add(new RewardPoolItem(ModContent.ItemType<Swordsplosion>(), 1));
+                p5.Add(new RewardPoolItem(ModContent.ItemType<MoonstoneCrown>(), 1));
+                p5.Add(new RewardPoolItem(ModContent.ItemType<ExodiumCluster>(), 1));
+                p5.Add(new RewardPoolItem(ModContent.ItemType<PlanetaryAnnihilation>(), 1));
+                p5.Add(new RewardPoolItem(ModContent.ItemType<StatisNinjaBelt>(), 1));
+                p5.Add(new RewardPoolItem(ModContent.ItemType<OccultSkullCrown>(), 1));
+                p5.Add(new RewardPoolItem(ModContent.ItemType<UltraLiquidator>(), 1));
+                p5.Add(new RewardPoolItem(ItemID.LastPrism, 1));
+
+                p6 = new RewardPool();
+                p6.Add(new RewardPoolItem(ModContent.ItemType<NightmareFuel>(), 25));
+                p6.Add(new RewardPoolItem(ModContent.ItemType<EndothermicEnergy>(), 25));
+                p6.Add(new RewardPoolItem(ModContent.ItemType<DarksunFragment>(), 25));
+                p6.Add(new RewardPoolItem(ModContent.ItemType<OmegaHealingPotion>(), 10));
+                p6.Add(new RewardPoolItem(ModContent.ItemType<CosmicDischarge>(), 1));
+                p6.Add(new RewardPoolItem(ModContent.ItemType<GalaxySmasher>(), 1));
+                p6.Add(new RewardPoolItem(ModContent.ItemType<Murasama>(), 1));
+                p6.Add(new RewardPoolItem(ModContent.ItemType<VoidEaterMarionette>(), 1));
+                p6.Add(new RewardPoolItem(ModContent.ItemType<MirrorofKalandra>(), 1));
+                p6.Add(new RewardPoolItem(ModContent.ItemType<Riftburst>(), 1));
+                p6.Add(new RewardPoolItem(ModContent.ItemType<Omicron>(), 1));
+
+                p7 = new RewardPool();
+                p7.Add(new RewardPoolItem(ModContent.ItemType<ChickenCannon>(), 1));
+                p7.Add(new RewardPoolItem(ModContent.ItemType<CodebreakerBase>(), 1));
+                p7.Add(new RewardPoolItem(ModContent.ItemType<YharimsCrystal>(), 1));
+                p7.Add(new RewardPoolItem(ModContent.ItemType<AscendantSpiritEssence>(), 15));
+                p7.Add(new RewardPoolItem(ModContent.ItemType<AuricOre>(), 100));
+                p7.Add(new RewardPoolItem(ModContent.ItemType<DragonsBreath>(), 1));
+                p7.Add(new RewardPoolItem(ModContent.ItemType<ArkoftheCosmos>(), 1));
+                p7.Add(new RewardPoolItem(ModContent.ItemType<DragonPow>(), 1));
+                p7.Add(new RewardPoolItem(ModContent.ItemType<Wrathwing>(), 1));
+                p7.Add(new RewardPoolItem(ModContent.ItemType<YharonSoulFragment>(), 10));
+                p7.Add(new RewardPoolItem(ModContent.ItemType<AuricBar>(), 5));
+                p7.Add(new RewardPoolItem(ItemID.Zenith, 1));
 
                 #endregion
             }
@@ -808,13 +864,26 @@ namespace CalamityEntropy.Content.NPCs
                                 pool.addPool(g2);
                                 pool.addPool(p2);
                             }
+                            if (NPC.downedPlantBoss)
+                            {
+                                pool.addPool(g3);
+                                pool.addPool(p3);
+                            }
+                            if (NPC.downedGolemBoss)
+                            {
+                                pool.addPool(p4);
+                            }
                             if (NPC.downedMoonlord)
                             {
-                                pool.addPool(p3);
+                                pool.addPool(p5);
+                            }
+                            if (DownedBossSystem.downedDoG)
+                            {
+                                pool.addPool(p6);
                             }
                             if (DownedBossSystem.downedYharon)
                             {
-                                pool.addPool(p4);
+                                pool.addPool(p7);
                             }
 
                             RewardPoolItem ri = pool.RandomItem();


### PR DESCRIPTION

1.抽奖机，大幅扩充了奖池，并且在其中加入了花后石后神后三个额外阶段，加入大量灾厄原本删除的便利性内容如地牢稀有物品、龙后复杂制作物品、冰龟壳等难以刷取的关键材料等，增加实用性
2.虚空分形，虚空波倍率降低至100%，但是虚空新星倍率由25%加强至33%，补全对终灾兄弟效果较差的短板
3.根据反馈降低了寻友护符召唤出的小怪的伤害，防止他们在前期相对于其他召唤武器过于强势，比如说殒命妖灵一个大冲冲荒灾一半血
4.灰烬笔录，面板调整至140以适配新版本对神吞和无尽虚空韧性方面的削弱
5.ftw世界中巡游者将不会增加额外长度和防御，体节大小略微降低，以降低难度