### PR TITLE
新重做武器的调整

### DIFF
--- a/CELists.cs
+++ b/CELists.cs
@@ -1,4 +1,4 @@
-﻿using CalamityEntropy.Content.Items.Weapons;
+using CalamityEntropy.Content.Items.Weapons;
 using CalamityEntropy.Content.Items.Weapons.Fractal;
 using CalamityEntropy.Content.Projectiles;
 using CalamityMod.Projectiles.Melee;
@@ -52,7 +52,8 @@ namespace CalamityEntropy
                 P<BatteringRamProj>(),
                 P<CinderConvergencerHoldout>(),
                 P<VoidAnnihilateCharge>(),
-                P<VoidAnnihilateSpawner>()
+                P<VoidAnnihilateSpawner>(),
+		        P<AzafureEKatanaSlash>()
             };
         }
         public static List<int> SoyMilkProjectileBlacklist;

--- a/Content/Items/Weapons/Fractal/VoidFractal.cs
+++ b/Content/Items/Weapons/Fractal/VoidFractal.cs
@@ -1,9 +1,11 @@
-﻿using CalamityEntropy.Common;
+using CalamityEntropy.Common;
 using CalamityEntropy.Content.Projectiles;
 using CalamityEntropy.Content.Rarities;
 using CalamityEntropy.Content.Tiles;
 using CalamityMod;
 using CalamityMod.Items;
+using CalamityMod.Items.Materials;
+using CalamityMod.Items.Weapons.Melee;
 using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
@@ -89,7 +91,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Fractal
         {
             CreateRecipe()
                 .AddIngredient<SpiritFractal>()
-                .AddIngredient<VoidAnnihilate>()
+                .AddIngredient<MawOfInfinity>()
                 .AddIngredient<VoidBar>(5)
                 .AddTile<VoidWellTile>()
                 .Register();

--- a/Content/Items/Weapons/VoidAnnihilate.cs
+++ b/Content/Items/Weapons/VoidAnnihilate.cs
@@ -1,8 +1,9 @@
-﻿using CalamityEntropy.Common;
+using CalamityEntropy.Common;
 using CalamityEntropy.Content.Projectiles;
 using CalamityEntropy.Content.Projectiles.TwistedTwin;
 using CalamityEntropy.Content.Rarities;
 using CalamityMod;
+using CalamityMod.Items;
 using System.Collections.Generic;
 using Terraria;
 using Terraria.DataStructures;
@@ -19,8 +20,8 @@ namespace CalamityEntropy.Content.Items.Weapons
         }
         public override void SetDefaults()
         {
-            Item.damage = 2400;
-            Item.crit = 8;
+            Item.damage = 1200;
+            Item.crit = 10;
             Item.DamageType = DamageClass.Melee;
             Item.width = 64;
             Item.noUseGraphic = true;
@@ -29,12 +30,12 @@ namespace CalamityEntropy.Content.Items.Weapons
             Item.useAnimation = 16;
             Item.useStyle = ItemUseStyleID.Swing;
             Item.knockBack = 6;
-            Item.value = 12000;
+            Item.value = CalamityGlobalItem.RarityVioletBuyPrice;
             Item.rare = ModContent.RarityType<VoidPurple>();
             Item.UseSound = null;
             Item.noMelee = true;
             Item.shoot = ModContent.ProjectileType<VoidAnnihilateCharge>();
-            Item.shootSpeed = 42f;
+            Item.shootSpeed = 75f;
             Item.ArmorPenetration = 50;
         }
         public override bool CanUseItem(Player player)


### PR DESCRIPTION
1.虚湮黯天，将售卖价格提升为与虚渺武器一致，面板降低至1200，暴击率提升至10，弹速提升至75增加实战稳定性
(实战适合半肉配置，在犽戎到终灾远程战士武器中最快能将终灾打入二阶段，左右键切换大约4万9（100甲木桩），对比禅心剑2万9，携序2万5，天底4万1，脊柱3万9，盖尔3万6，焚天4万2，神谕3万6，天顶3万2）
2.虚空分形，将配方里的虚湮黯天替换为永噬之颚
3.阿萨辐勒电太刀，将射弹加入了豆奶的打表中