### PR TITLE
新重做武器的调整

### DIFF
--- a/Content/Items/Weapons/Silence.cs
+++ b/Content/Items/Weapons/Silence.cs
@@ -1,4 +1,4 @@
-﻿using CalamityEntropy.Common;
+using CalamityEntropy.Common;
 using CalamityEntropy.Content.Particles;
 using CalamityEntropy.Content.Projectiles;
 using CalamityEntropy.Content.Rarities;
@@ -29,7 +29,7 @@ namespace CalamityEntropy.Content.Items.Weapons
         {
             Item.width = 36;
             Item.height = 34;
-            Item.damage = 2600;
+            Item.damage = 1750;
             Item.noMelee = true;
             Item.noUseGraphic = true;
             Item.useAnimation = Item.useTime = 32;
@@ -53,7 +53,7 @@ namespace CalamityEntropy.Content.Items.Weapons
         }
 
 
-        public override float StealthDamageMultiplier => 1.4f;
+        public override float StealthDamageMultiplier => 0.35f;
         public override float StealthVelocityMultiplier => 1.2f;
         public override float StealthKnockbackMultiplier => 0f;
 

--- a/Content/Items/Weapons/WingsOfHush.cs
+++ b/Content/Items/Weapons/WingsOfHush.cs
@@ -1,4 +1,4 @@
-﻿using CalamityEntropy.Content.Projectiles;
+using CalamityEntropy.Content.Projectiles;
 using CalamityEntropy.Content.Rarities;
 using CalamityMod.Items;
 using Microsoft.Xna.Framework.Graphics;
@@ -16,7 +16,7 @@ namespace CalamityEntropy.Content.Items.Weapons
         {
             Item.width = 30;
             Item.height = 44;
-            Item.damage = 920;
+            Item.damage = 800;
             Item.DamageType = DamageClass.Ranged;
             Item.useTime = 16;
             Item.useAnimation = 16;
@@ -40,10 +40,10 @@ namespace CalamityEntropy.Content.Items.Weapons
             flag = true;
             int p = Projectile.NewProjectile(source, position + velocity.normalize() * 32, velocity, ModContent.ProjectileType<WohLaser>(), damage, knockback, player.whoAmI);
 
-            Projectile.NewProjectile(source, position + velocity.normalize() * Item.shootSpeed + velocity.normalize().RotatedBy(MathHelper.PiOver2) * 18, velocity.RotatedBy(MathHelper.ToRadians(3)) + player.velocity * 0.2f, ModContent.ProjectileType<WohShot>(), (int)(damage * 0.6f), knockback, player.whoAmI, 0, Main.MouseWorld.X, Main.MouseWorld.Y);
-            Projectile.NewProjectile(source, position + velocity.normalize() * Item.shootSpeed + velocity.normalize().RotatedBy(MathHelper.PiOver2) * -18, velocity.RotatedBy(MathHelper.ToRadians(-3)) + player.velocity * 0.2f, ModContent.ProjectileType<WohShot>(), (int)(damage * 0.6f), knockback, player.whoAmI, 0, Main.MouseWorld.X, Main.MouseWorld.Y);
-            Projectile.NewProjectile(source, position + velocity.normalize() * Item.shootSpeed + velocity.normalize().RotatedBy(MathHelper.PiOver2) * 18, velocity.RotatedBy(MathHelper.ToRadians(6)) + player.velocity * 0.2f, ModContent.ProjectileType<WohShot>(), (int)(damage * 0.6f), knockback, player.whoAmI, 0, Main.MouseWorld.X, Main.MouseWorld.Y);
-            Projectile.NewProjectile(source, position + velocity.normalize() * Item.shootSpeed + velocity.normalize().RotatedBy(MathHelper.PiOver2) * -18, velocity.RotatedBy(MathHelper.ToRadians(-6)) + player.velocity * 0.2f, ModContent.ProjectileType<WohShot>(), (int)(damage * 0.6f), knockback, player.whoAmI, 0, Main.MouseWorld.X, Main.MouseWorld.Y);
+            Projectile.NewProjectile(source, position + velocity.normalize() * Item.shootSpeed + velocity.normalize().RotatedBy(MathHelper.PiOver2) * 18, velocity.RotatedBy(MathHelper.ToRadians(3)) + player.velocity * 0.2f, ModContent.ProjectileType<WohShot>(), (int)(damage * 0.3f), knockback, player.whoAmI, 0, Main.MouseWorld.X, Main.MouseWorld.Y);
+            Projectile.NewProjectile(source, position + velocity.normalize() * Item.shootSpeed + velocity.normalize().RotatedBy(MathHelper.PiOver2) * -18, velocity.RotatedBy(MathHelper.ToRadians(-3)) + player.velocity * 0.2f, ModContent.ProjectileType<WohShot>(), (int)(damage * 0.3f), knockback, player.whoAmI, 0, Main.MouseWorld.X, Main.MouseWorld.Y);
+            Projectile.NewProjectile(source, position + velocity.normalize() * Item.shootSpeed + velocity.normalize().RotatedBy(MathHelper.PiOver2) * 18, velocity.RotatedBy(MathHelper.ToRadians(6)) + player.velocity * 0.2f, ModContent.ProjectileType<WohShot>(), (int)(damage * 0.3f), knockback, player.whoAmI, 0, Main.MouseWorld.X, Main.MouseWorld.Y);
+            Projectile.NewProjectile(source, position + velocity.normalize() * Item.shootSpeed + velocity.normalize().RotatedBy(MathHelper.PiOver2) * -18, velocity.RotatedBy(MathHelper.ToRadians(-6)) + player.velocity * 0.2f, ModContent.ProjectileType<WohShot>(), (int)(damage * 0.3f), knockback, player.whoAmI, 0, Main.MouseWorld.X, Main.MouseWorld.Y);
             return false;
         }
         public override void HoldItem(Player player)


### PR DESCRIPTION
1.沉默，面板降低为1750，潜伏倍率降低至35%，使得其潜伏普攻实战伤害相近但是潜伏对群更好，实战中作为微原劫掠者的上位使用
2.虚寂之翼，面板降低至800，四发虚空矢的倍率降低至30%，实战能对单稳定3万8左右，比渺光和虚炮高