### PR TITLE
新武器

### DIFF
--- a/Content/Items/Donator/YoungMaster.cs
+++ b/Content/Items/Donator/YoungMaster.cs
@@ -400,7 +400,7 @@ namespace CalamityEntropy.Content.Items.Donator
         public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
         {
             CEUtils.PlaySound("VividClarityBeamAppear", 1, Projectile.Center);
-            Projectile.NewProjectile(Projectile.GetSource_FromAI(), target.Center, Vector2.Zero, ModContent.ProjectileType<YoungMasterMark>(), Projectile.damage / 3, 0, Projectile.owner);
+            Projectile.NewProjectile(Projectile.GetSource_FromAI(), target.Center, Vector2.Zero, ModContent.ProjectileType<YoungMasterMark>(), Projectile.damage / 2, 0, Projectile.owner);
         }
     }
     public class YoungMasterMark : ModProjectile

--- a/Content/Items/Donator/YoungMaster.cs
+++ b/Content/Items/Donator/YoungMaster.cs
@@ -28,9 +28,8 @@ namespace CalamityEntropy.Content.Items.Donator
         {
             CreateRecipe()
                 .AddIngredient<SaharaSlicers>()
-                .AddIngredient<HellIndustrialComponents>(6)
-                .AddRecipeGroup(CERecipeGroups.AnyOrichalcumBar, 8)
-                .AddIngredient(ItemID.SoulofMight, 4)
+                .AddIngredient(ItemID.TitaniumBar, 10)
+                .AddIngredient(ItemID.SoulofMight, 15)
                 .AddTile(TileID.MythrilAnvil)
                 .Register();
         }
@@ -39,7 +38,7 @@ namespace CalamityEntropy.Content.Items.Donator
         {
             Item.width = 120;
             Item.height = 120;
-            Item.damage = 80;
+            Item.damage = 125;
             Item.crit = 10;
             Item.noMelee = true;
             Item.noUseGraphic = true;
@@ -148,7 +147,7 @@ namespace CalamityEntropy.Content.Items.Donator
                 EParticle.spawnNew(new ShineParticle(), Projectile.Center + Projectile.velocity.normalize() * 80, Vector2.Zero, Color.White, 2.4f, 1, true, BlendState.Additive, 0, 16);
                 if (Projectile.owner == Main.myPlayer)
                 {
-                    CEUtils.SpawnExplotionFriendly(Projectile.GetSource_FromAI(), Projectile.owner.ToPlayer(), Projectile.Center + Projectile.velocity.normalize() * 80, Projectile.damage / 3, 160, Projectile.DamageType);
+                    CEUtils.SpawnExplotionFriendly(Projectile.GetSource_FromAI(), Projectile.owner.ToPlayer(), Projectile.Center + Projectile.velocity.normalize() * 80, Projectile.damage / 8, 160, Projectile.DamageType);
                 }
                 for (int i = 0; i < 32; i++)
                 {
@@ -401,7 +400,7 @@ namespace CalamityEntropy.Content.Items.Donator
         public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
         {
             CEUtils.PlaySound("VividClarityBeamAppear", 1, Projectile.Center);
-            Projectile.NewProjectile(Projectile.GetSource_FromAI(), target.Center, Vector2.Zero, ModContent.ProjectileType<YoungMasterMark>(), Projectile.damage / 2, 0, Projectile.owner);
+            Projectile.NewProjectile(Projectile.GetSource_FromAI(), target.Center, Vector2.Zero, ModContent.ProjectileType<YoungMasterMark>(), Projectile.damage / 3, 0, Projectile.owner);
         }
     }
     public class YoungMasterMark : ModProjectile

--- a/Content/Items/Weapons/ProphecyFlyingKnife.cs
+++ b/Content/Items/Weapons/ProphecyFlyingKnife.cs
@@ -25,8 +25,8 @@ namespace CalamityEntropy.Content.Items.Weapons
         {
             Item.width = 60;
             Item.height = 60;
-            Item.damage = 28;
-            Item.ArmorPenetration = 32;
+            Item.damage = 30;
+            Item.ArmorPenetration = 30;
             Item.noMelee = true;
             Item.noUseGraphic = true;
             Item.useAnimation = Item.useTime = 20;

--- a/Content/Items/Weapons/VoidRelics.cs
+++ b/Content/Items/Weapons/VoidRelics.cs
@@ -25,12 +25,12 @@ namespace CalamityEntropy.Content.Items.Weapons
             ItemID.Sets.GamepadWholeScreenUseRange[Item.type] = true;
             ItemID.Sets.LockOnIgnoresCollision[Item.type] = true;
             ItemID.Sets.ItemNoGravity[Item.type] = true;
-            ItemID.Sets.StaffMinionSlotsRequired[Item.type] = 5;
+            ItemID.Sets.StaffMinionSlotsRequired[Item.type] = 4;
         }
 
         public override void SetDefaults()
         {
-            Item.damage = 2200;
+            Item.damage = 370;
             Item.crit = 0;
             Item.DamageType = DamageClass.Summon;
             Item.width = 64;
@@ -94,7 +94,7 @@ namespace CalamityEntropy.Content.Items.Weapons
             Projectile.tileCollide = false;
             Projectile.light = 1f;
             Projectile.minion = true;
-            Projectile.minionSlots = 5;
+            Projectile.minionSlots = 4;
             Projectile.usesLocalNPCImmunity = true;
             Projectile.localNPCHitCooldown = 16;
         }


### PR DESCRIPTION
1.贵公子，在和捐赠者协商后将配方修改为撒哈拉双刃+10钛金锭+15力量之魂，面板提升至125加强对单，爆炸倍率降低至12.5%削弱超雄对群能力
2.预言飞刀，面板提升至30，穿甲略微降低，使其介于源野天光和星体暴乱间，花后轮椅位
3.虚空圣契，面板降低至370，所需栏位和文本显示栏位降低至4，方便和终焉百合一起补位，将其强度大概调整为：不用特殊技能时，总体作用强于天龙（天龙现在比魔镜强）和4栏幻梦崩影，使用技能时略强于灾后强力召唤物硫心恶殖