### PR TITLE
剑匣血亲

### DIFF
--- a/Common/EModPlayer.cs
+++ b/Common/EModPlayer.cs
@@ -1493,7 +1493,7 @@ namespace CalamityEntropy.Common
                 sJudgeCd -= 1;
                 if (sJudgeCd <= 0)
                 {
-                    sJudgeCd = (30 * 60).ApplyCdDec(Player);
+                    sJudgeCd = (90 * 60).ApplyCdDec(Player);
                     SacredJudgeShields += 1;
                 }
             }

--- a/Content/Items/Weapons/CrystalBalls/EyeOfOtherside.cs
+++ b/Content/Items/Weapons/CrystalBalls/EyeOfOtherside.cs
@@ -14,7 +14,7 @@ namespace CalamityEntropy.Content.Items.Weapons.CrystalBalls
         {
             Item.width = 44;
             Item.height = 44;
-            Item.damage = 326;
+            Item.damage = 270;
             Item.noMelee = true;
             Item.noUseGraphic = true;
             Item.useAnimation = Item.useTime = 20;

--- a/Content/Items/Weapons/Fractal/SpiritFractal.cs
+++ b/Content/Items/Weapons/Fractal/SpiritFractal.cs
@@ -20,7 +20,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Fractal
     {
         public override void SetDefaults()
         {
-            Item.damage = 290;
+            Item.damage = 265;
             Item.crit = 10;
             Item.DamageType = DamageClass.Melee;
             Item.width = 48;

--- a/Content/Items/Weapons/HorizonssKey.cs
+++ b/Content/Items/Weapons/HorizonssKey.cs
@@ -1,4 +1,4 @@
-﻿using CalamityEntropy.Common;
+using CalamityEntropy.Common;
 using CalamityEntropy.Content.Projectiles.SamsaraCasket;
 using CalamityMod;
 using CalamityMod.Buffs.StatDebuffs;
@@ -31,7 +31,11 @@ namespace CalamityEntropy.Content.Items.Weapons
         {
             if (damageClass == CEUtils.RogueDC)
             {
-                return new StatInheritanceData(0.35f, 0.35f, 0.35f, 0.35f, 0.35f);
+                return new StatInheritanceData(0.2f, 0.2f, 0.2f, 0.2f, 0.2f);
+            }
+	    if (damageClass == Summon)
+            {
+                return new StatInheritanceData(0.3f, 0.3f, 0.3f, 0.3f, 0.3f);
             }
             return StatInheritanceData.Full;
         }
@@ -154,7 +158,7 @@ namespace CalamityEntropy.Content.Items.Weapons
             {
                 ap += 30;
             }
-            ap += 46 * Main.LocalPlayer.Entropy().WeaponBoost;
+            ap += 10 * Main.LocalPlayer.Entropy().WeaponBoost;
             return ap;
         }
         public static int getLevel()
@@ -253,39 +257,39 @@ namespace CalamityEntropy.Content.Items.Weapons
             float ad = 0.7f;
             if (NPC.downedSlimeKing)
             {
-                ad += 0.22f;
+                ad += 0.2f;
             }
             if (NPC.downedBoss1)
             {
-                ad += 0.24f;
+                ad += 0.2f;
             }
             if (NPC.downedBoss2)
             {
-                ad += 0.24f;
+                ad += 0.2f;
             }
             if (NPC.downedBoss3)
             {
-                ad += 0.3f;
+                ad += 0.1f;
             }
             if (Main.hardMode)
             {
-                ad += 0.3f;
+                ad += 0.65f;
             }
             if (DownedBossSystem.downedCryogen)
             {
-                ad += 0.26f;
+                ad += 0.3f;
             }
             if (NPC.downedGolemBoss)
             {
-                ad += 0.1f;
+                ad += 0.2f;
             }
             if (NPC.downedAncientCultist)
             {
-                ad += 0.1f;
+                ad += 0.15f;
             }
             if (NPC.downedMoonlord)
             {
-                ad += 1.0f;
+                ad += 0.5f;
             }
             if (DownedBossSystem.downedProvidence)
             {
@@ -305,11 +309,11 @@ namespace CalamityEntropy.Content.Items.Weapons
             }
             if (DownedBossSystem.downedDoG)
             {
-                ad += 0.5f;
+                ad += 0.6f;
             }
             if (DownedBossSystem.downedYharon)
             {
-                ad += 1.0f;
+                ad += 1.75f;
             }
             if (DownedBossSystem.downedExoMechs)
             {
@@ -317,11 +321,11 @@ namespace CalamityEntropy.Content.Items.Weapons
             }
             if (DownedBossSystem.downedCalamitas)
             {
-                ad += 0.8f;
+                ad += 0.3f;
             }
             if (DownedBossSystem.downedExoMechs && DownedBossSystem.downedCalamitas)
             {
-                ad += 0.5f;
+                ad += 0.75f;
             }
             if (DownedBossSystem.downedBossRush)
             {
@@ -355,6 +359,5 @@ namespace CalamityEntropy.Content.Items.Weapons
                 .AddIngredient(ModContent.ItemType<LoreAwakening>())
                 .AddTile(TileID.WorkBenches).Register();
         }
-
     }
 }

--- a/Content/Items/Weapons/HorizonssKey.cs
+++ b/Content/Items/Weapons/HorizonssKey.cs
@@ -321,7 +321,7 @@ namespace CalamityEntropy.Content.Items.Weapons
             }
             if (DownedBossSystem.downedCalamitas)
             {
-                ad += 0.3f;
+                ad += 0.5f;
             }
             if (DownedBossSystem.downedExoMechs && DownedBossSystem.downedCalamitas)
             {
@@ -329,7 +329,7 @@ namespace CalamityEntropy.Content.Items.Weapons
             }
             if (DownedBossSystem.downedBossRush)
             {
-                ad += 1.5f;
+                ad += 2.0f;
             }
             return ad;
         }

--- a/Content/Items/Weapons/Kinanition.cs
+++ b/Content/Items/Weapons/Kinanition.cs
@@ -1,4 +1,4 @@
-﻿using CalamityEntropy.Content.Projectiles;
+using CalamityEntropy.Content.Projectiles;
 using CalamityMod;
 using CalamityMod.Items.Materials;
 using CalamityMod.Items.Weapons.Ranged;
@@ -26,7 +26,7 @@ namespace CalamityEntropy.Content.Items.Weapons
         }
         public override void SetDefaults()
         {
-            Item.damage = 46;
+            Item.damage = 25;
             Item.DamageType = DamageClass.Ranged;
             Item.width = 36;
             Item.height = 110;
@@ -41,8 +41,8 @@ namespace CalamityEntropy.Content.Items.Weapons
             Item.shootSpeed = 20f;
             Item.useAmmo = AmmoID.Arrow;
             Item.autoReuse = true;
-            Item.ArmorPenetration = 12;
-            Item.value = 8000;
+            Item.ArmorPenetration = 30;
+            Item.value = Item.buyPrice(gold: 12);
             Item.rare = ItemRarityID.Purple;
         }
 

--- a/Content/Projectiles/SamsaraCasket/Recovery.cs
+++ b/Content/Projectiles/SamsaraCasket/Recovery.cs
@@ -16,7 +16,7 @@ namespace CalamityEntropy.Content.Projectiles.SamsaraCasket
         public override void SetDefaults()
         {
             base.SetDefaults();
-            Projectile.localNPCHitCooldown = 8;
+            Projectile.localNPCHitCooldown = 12;
         }
         public override void AI()
         {
@@ -60,7 +60,7 @@ namespace CalamityEntropy.Content.Projectiles.SamsaraCasket
                     }
                     if (counter % 60 == 0)
                     {
-                        Projectile.NewProjectile(Projectile.GetSource_FromAI(), t.Center, CEUtils.randomRot().ToRotationVector2() * 26, ModContent.ProjectileType<RecoveryVineTop>(), (int)(Projectile.damage * 0.7f), Projectile.knockBack, Projectile.owner);
+                        Projectile.NewProjectile(Projectile.GetSource_FromAI(), t.Center, CEUtils.randomRot().ToRotationVector2() * 26, ModContent.ProjectileType<RecoveryVineTop>(), (int)(Projectile.damage * 0.5f), Projectile.knockBack, Projectile.owner);
                     }
                 }
             }

--- a/Content/Projectiles/SamsaraCasket/SacredJudge.cs
+++ b/Content/Projectiles/SamsaraCasket/SacredJudge.cs
@@ -14,7 +14,7 @@ namespace CalamityEntropy.Content.Projectiles.SamsaraCasket
         public override void SetDefaults()
         {
             base.SetDefaults();
-            Projectile.localNPCHitCooldown = 10;
+            Projectile.localNPCHitCooldown = 20;
         }
         public bool shieldLast = false;
         public override void AI()

--- a/Content/Projectiles/SamsaraCasket/SoulDissipate.cs
+++ b/Content/Projectiles/SamsaraCasket/SoulDissipate.cs
@@ -14,7 +14,7 @@ namespace CalamityEntropy.Content.Projectiles.SamsaraCasket
         }
         public override void attackAI(NPC t)
         {
-            setDamage(2);
+            setDamage(1);
             if (counter % 10 == 0)
             {
                 SoundEngine.PlaySound(SoundID.Item74, Projectile.position);


### PR DESCRIPTION
1.重新调整了视界之键，将其基本的成长倍率大幅提升，穿甲按等级的提升倍率降低至10:1，延长圣裁攻击的无敌帧并且将圣裁护盾的cd延长至90秒，繁花藤蔓的倍率降低20%，宇宙之剑的倍率减半以平衡面板提升。同时，现在剑匣只能吃到20%潜伏伤害加成和30%召唤伤害加成，使五职业使用本武器的强度更加接近。
2.聚魂分形的面板降低至265，使得其对犽戎的强度不会比神吞武器强
3.彼岸之眼的面板降低至270，直接在实战老核弹中对标鬼之形，强于部分宇宙武器
4.孱弱血亲的面板降低至25，但是穿甲提升至30售卖价格提升至12，使其在面对50甲目标时（猪，光，歌莉娅），左键搭配高面板箭矢对标海啸和日暮，右键对标瘟疫散播者，略弱于四柱武器，同时强于石后武器和常规魔像/t3旧日军团武器