### PR TITLE
一些小平衡

### DIFF
--- a/CalamityEntropy.cs
+++ b/CalamityEntropy.cs
@@ -364,10 +364,10 @@ namespace CalamityEntropy
             if (info.Damage < leastDmg)
                 info.Damage = leastDmg;
 
-            if (self.Entropy().deusCore && info.Damage > 5)
+            if (self.Entropy().deusCore && info.Damage > 20)
             {
-                self.Entropy().deusCoreBloodOut += info.Damage - 5;
-                info.Damage = 5;
+                self.Entropy().deusCoreBloodOut += info.Damage - 20;
+                info.Damage = 20;
             }
             if (self.Entropy().NihTwinArmorConnetPlayer != -1)
             {

--- a/Content/Items/Weapons/Erebodrepanon.cs
+++ b/Content/Items/Weapons/Erebodrepanon.cs
@@ -20,7 +20,7 @@ namespace CalamityEntropy.Content.Items.Weapons
     {
         public override void SetDefaults()
         {
-            Item.damage = 9000;
+            Item.damage = 10000;
             Item.crit = 20;
             Item.DamageType = ModContent.GetInstance<TrueMeleeDamageClass>();
             Item.width = 132;
@@ -51,7 +51,8 @@ namespace CalamityEntropy.Content.Items.Weapons
         {
             CreateRecipe()
                 .AddIngredient<DeathsAscension>()
-                .AddIngredient<FadingRunestone>(2)
+                .AddIngredient(ModContent.ItemType<WyrmTooth>(), 12)
+                .AddIngredient<FadingRunestone>()
                 .AddTile<AbyssalAltarTile>()
                 .Register();
         }
@@ -186,7 +187,7 @@ namespace CalamityEntropy.Content.Items.Weapons
             {
                 if (Projectile.numHits < 3)
                 {
-                    Projectile.NewProjectile(Projectile.GetSource_FromAI(), target.Center, Vector2.Zero, ModContent.ProjectileType<ErebodrepanonMark>(), Projectile.damage, 0, Projectile.owner, 0, 0, target.whoAmI);
+                    Projectile.NewProjectile(Projectile.GetSource_FromAI(), target.Center, Vector2.Zero, ModContent.ProjectileType<ErebodrepanonMark>(), (int)(Projectile.damage * 0.4f), 0, Projectile.owner, 0, 0, target.whoAmI);
                 }
             }
             target.AddBuff<LifeOppress>(5 * 60);

--- a/Content/Items/Weapons/Fractal/FinalFractal.cs
+++ b/Content/Items/Weapons/Fractal/FinalFractal.cs
@@ -56,8 +56,8 @@ namespace CalamityEntropy.Content.Items.Weapons.Fractal
             if (player.altFunctionUse == 2)
             {
                 CEUtils.PlaySound("VoidAnticipation", 1, position, volume: CEUtils.WeapSound);
-                player.AddBuff(BuffID.ChaosState, 5 * 60);
-                Projectile.NewProjectile(source, position, velocity * 4, ModContent.ProjectileType<VoidSlash>(), damage * 15, 0, player.whoAmI, 1);
+                player.AddBuff(BuffID.ChaosState, 10 * 60);
+                Projectile.NewProjectile(source, position, velocity * 4, ModContent.ProjectileType<VoidSlash>(), damage * 10, 0, player.whoAmI, 1);
                 return false;
             }
             int at = 2;

--- a/Content/Items/Weapons/HadopelagicEchoII.cs
+++ b/Content/Items/Weapons/HadopelagicEchoII.cs
@@ -28,7 +28,7 @@ namespace CalamityEntropy.Content.Items.Weapons
             Item.rare = ModContent.RarityType<AbyssalBlue>();
             Item.shoot = ModContent.ProjectileType<HadopelagicEchoIIProj>();
             Item.shootSpeed = 16f;
-            Item.mana = 25;
+            Item.mana = 100;
             Item.DamageType = DamageClass.Magic;
             Item.ArmorPenetration = 100;
         }

--- a/Content/Items/Weapons/Nyxolithraken.cs
+++ b/Content/Items/Weapons/Nyxolithraken.cs
@@ -22,7 +22,7 @@ namespace CalamityEntropy.Content.Items.Weapons
 
         public override void SetDefaults()
         {
-            Item.damage = 2000;
+            Item.damage = 1750;
             Item.crit = 0;
             Item.DamageType = DamageClass.Summon;
             Item.width = 90;

--- a/Content/Items/Weapons/Xytheron.cs
+++ b/Content/Items/Weapons/Xytheron.cs
@@ -14,7 +14,7 @@ namespace CalamityEntropy.Content.Items.Weapons
     {
         public override void SetDefaults()
         {
-            Item.damage = 11500;
+            Item.damage = 9200;
             Item.crit = 20;
             Item.DamageType = ModContent.GetInstance<TrueMeleeDamageClass>();
             Item.width = 86;
@@ -58,7 +58,7 @@ namespace CalamityEntropy.Content.Items.Weapons
                 player.RemoveAllGrapplingHooks();
                 if (player.mount.Active)
                     player.mount.Dismount(player);
-                Projectile.NewProjectile(source, position, velocity.SafeNormalize(Vector2.UnitX) * (42 + charge * 1.9f), type, (int)(damage / 4.0f * (charge + 1)), knockback, player.whoAmI, charge);
+                Projectile.NewProjectile(source, position, velocity.SafeNormalize(Vector2.UnitX) * (42 + charge * 1.9f), type, (int)(damage / 3.6f * (charge + 1)), knockback, player.whoAmI, charge);
                 charge = 0;
             }
             else


### PR DESCRIPTION
1.妖龙镰刀，配方修改为死神擢升+12妖龙牙+1符石，深渊标记伤害倍率降低至40%，面板提升至10000，使其达到妖龙系列标准线（激怒无限大地）
2.妖龙大剑，面板降低至9200，冲刺倍率提升10%，因为和镰刀攻击方式过于重叠，因此略微降低其伤害，使其常规状态下伤害略微低于镰刀但是算上冲刺后高于镰刀
3.幽邃分形，削弱其过分强大的右键，造成的混沌减益时间延长至10秒，倍率降低至1000%，使其对整体武器dps的提升和妖龙大冲一样约为30%。
4.沧溟龙契，面板降低至1750，使其在毕业环境下的伤害和其他妖龙武器接近（激怒无限大地），不明显强于其他妖龙武器。
5.妖龙mk2，魔力消耗提升至100以加强其与混乱石的适配程度，提升启动负魔力焚烧敌怪的速度，正常玩使用无垠也几乎不会受魔力病影响
6.星神龙核的最小受伤值提升至20，使其能够正常触发一部分闪避效果，同时保留其能够保护神条的特性