### PR TITLE
旋刃

### DIFF
--- a/Content/Buffs/WhipDebuff.cs
+++ b/Content/Buffs/WhipDebuff.cs
@@ -299,7 +299,7 @@ namespace CalamityEntropy.Content.Buffs
                     {
                         if(Main.rand.NextBool(5))
                         {
-                            Projectile.NewProjectile(projectile.GetSource_FromAI(), npc.Center, CEUtils.randomRot().ToRotationVector2() * Main.rand.NextFloat(16, 22), ModContent.ProjectileType<TectonicShardHomingSummon>(), (int)(projectile.damage * 0.7f) + 1, 2, projectile.owner);
+                            Projectile.NewProjectile(projectile.GetSource_FromAI(), npc.Center, CEUtils.randomRot().ToRotationVector2() * Main.rand.NextFloat(16, 22), ModContent.ProjectileType<TectonicShardHomingSummon>(), (int)(projectile.damage * 0.33f) + 1, 2, projectile.owner);
                         }
                     }
                     if (t.EffectName == "MindCorruptor")

--- a/Content/Items/Donator/Jy/Silentpeak.cs
+++ b/Content/Items/Donator/Jy/Silentpeak.cs
@@ -76,7 +76,7 @@ namespace CalamityEntropy.Content.Items.Donator.Jy
             6 => 55,
             7 => 85,
             8 => 115,
-            9 => 160,
+            9 => 150,
             10 => 210,
             11 => 400,
             _ => 400

--- a/Content/Items/Donator/Jy/Silentpeak.cs
+++ b/Content/Items/Donator/Jy/Silentpeak.cs
@@ -67,19 +67,19 @@ namespace CalamityEntropy.Content.Items.Donator.Jy
         }
         public static int GetDamage(int level) => level switch
         {
-            0 => 9,
-            1 => 20,
-            2 => 32,
-            3 => 45,
-            4 => 60,
-            5 => 80,
-            6 => 100,
-            7 => 200,
-            8 => 300,
-            9 => 400,
-            10 => 580,
-            11 => 800,
-            _ => 870
+            0 => 5,
+            1 => 9,
+            2 => 12,
+            3 => 16,
+            4 => 22,
+            5 => 42,
+            6 => 55,
+            7 => 85,
+            8 => 115,
+            9 => 160,
+            10 => 210,
+            11 => 400,
+            _ => 400
         };
         public static int Level()
         {

--- a/Content/Items/Weapons/BottledStarlightCocoon.cs
+++ b/Content/Items/Weapons/BottledStarlightCocoon.cs
@@ -31,7 +31,7 @@ namespace CalamityEntropy.Content.Items.Weapons
         }
         public override void SetDefaults()
         {
-            Item.damage = 34;
+            Item.damage = 30;
             Item.DamageType = DamageClass.Summon;
             Item.width = 22;
             Item.height = 26;

--- a/Content/Items/Weapons/HadopelagicEchoII.cs
+++ b/Content/Items/Weapons/HadopelagicEchoII.cs
@@ -16,7 +16,7 @@ namespace CalamityEntropy.Content.Items.Weapons
         {
             Item.width = 126;
             Item.height = 66;
-            Item.damage = 14000;
+            Item.damage = 12500;
             Item.noMelee = true;
             Item.noUseGraphic = true;
             Item.useAnimation = Item.useTime = 30;

--- a/Content/Items/Weapons/LunarPlank.cs
+++ b/Content/Items/Weapons/LunarPlank.cs
@@ -38,7 +38,7 @@ namespace CalamityEntropy.Content.Items.Weapons
             Item.crit = 4;
         }
 
-        public override float StealthDamageMultiplier => 1.16f;
+        public override float StealthDamageMultiplier => 0.9f;
         public override float StealthVelocityMultiplier => 1.4f;
 
         public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)

--- a/Content/Items/Weapons/Swirlblades/AzafureSwirlblade.cs
+++ b/Content/Items/Weapons/Swirlblades/AzafureSwirlblade.cs
@@ -31,8 +31,8 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
             Item.useAnimation = Item.useTime = 46;
             Item.width = 74;
             Item.height = 70;
-            Item.damage = 90;
-            Item.ArmorPenetration = 15;
+            Item.damage = 32;
+            Item.ArmorPenetration = 10;
             Item.UseSound = SoundID.Item1 with { Volume = 1.2f, Pitch = -0.32f };
             Item.value = CalamityGlobalItem.RarityLightRedBuyPrice;
             Item.rare = ModContent.RarityType<AzafureOrange>();
@@ -45,7 +45,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
             Item.noMelee = true;
             Item.noUseGraphic = true;
         }
-        public override float StealthDamageMultiplier => 1.14f;
+        public override float StealthDamageMultiplier => 0.75f;
         public override float StealthVelocityMultiplier => 1.2f;
 
         public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
@@ -65,7 +65,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
                 .AddIngredient(ModContent.ItemType<ScorchingChakram>())
                 .AddIngredient(ModContent.ItemType<HellIndustrialComponents>(), 6)
                 .AddRecipeGroup(CERecipeGroups.AnyOrichalcumBar, 8)
-                .AddTile(TileID.Anvils)
+                .AddTile(TileID.MythrilAnvil)
                 .Register();
         }
         public override bool MeleePrefix()

--- a/Content/Items/Weapons/Swirlblades/AzafureSwirlblade.cs
+++ b/Content/Items/Weapons/Swirlblades/AzafureSwirlblade.cs
@@ -65,7 +65,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
                 .AddIngredient(ModContent.ItemType<ScorchingChakram>())
                 .AddIngredient(ModContent.ItemType<HellIndustrialComponents>(), 6)
                 .AddRecipeGroup(CERecipeGroups.AnyOrichalcumBar, 8)
-                .AddTile(TileID.MythrilAnvil)
+                .AddTile(TileID.Anvils)
                 .Register();
         }
         public override bool MeleePrefix()

--- a/Content/Items/Weapons/Swirlblades/BlazingSwirlblade.cs
+++ b/Content/Items/Weapons/Swirlblades/BlazingSwirlblade.cs
@@ -32,8 +32,8 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
             Item.useAnimation = Item.useTime = 30;
             Item.width = 74;
             Item.height = 74;
-            Item.damage = 750;
-            Item.ArmorPenetration = 36;
+            Item.damage = 200;
+            Item.ArmorPenetration = 25;
             Item.UseSound = SoundID.Item1;
             Item.value = CalamityGlobalItem.RarityTurquoiseBuyPrice;
             Item.rare = ModContent.RarityType<Turquoise>();
@@ -46,7 +46,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
             Item.noMelee = true;
             Item.noUseGraphic = true;
         }
-        public override float StealthDamageMultiplier => 0.8f;
+        public override float StealthDamageMultiplier => 0.35f;
         public override float StealthVelocityMultiplier => 1.4f;
 
         public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
@@ -64,7 +64,6 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
         {
             CreateRecipe()
                 .AddIngredient(ModContent.ItemType<RunicSwirlblade>())
-                .AddIngredient(ModContent.ItemType<MoltenAmputator>())
                 .AddIngredient<DivineGeode>(12)
                 .AddIngredient<UnholyEssence>(8)
                 .AddTile(TileID.MythrilAnvil)
@@ -177,7 +176,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
             }
             if (Main.myPlayer == Projectile.owner)
             {
-                Projectile.NewProjectile(Projectile.GetSource_FromThis(), Projectile.Center, Vector2.Zero, ModContent.ProjectileType<BlazingSwirlbladeFlame>(), Projectile.damage * 2, 0, Projectile.owner, 0, Projectile.Calamity().stealthStrike ? 0.25f : 0);
+                Projectile.NewProjectile(Projectile.GetSource_FromThis(), Projectile.Center, Vector2.Zero, ModContent.ProjectileType<BlazingSwirlbladeFlame>(), (int)(Projectile.damage * 0.66f), 0, Projectile.owner, 0, Projectile.Calamity().stealthStrike ? 0.25f : 0);
             }
         }
         public int fhCd = 0;
@@ -220,7 +219,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
                     GeneralParticleHandler.SpawnParticle(new CustomPulse(target.Center, Vector2.Zero, Color.Lerp(new Color(255, 255, 160), new Color(255, 255, 0), i) * i, "CalamityMod/Particles/ShatteredExplosion", Vector2.One, CEUtils.randomRot(), 0.005f * i * (Radius / 180f), scale * 0.07f * i * (Radius / 180f), 12 + (int)(i * 8)));
                     GeneralParticleHandler.SpawnParticle(new CustomPulse(target.Center, Vector2.Zero, Color.Lerp(new Color(255, 255, 190), new Color(255, 255, 0), i) * i, "CalamityMod/Particles/SoftRoundExplosion", Vector2.One, CEUtils.randomRot(), 0.0046f * i * (Radius / 180f), scale * 0.06f * i * (Radius / 180f), 12 + (int)(i * 8)));
                 }
-                CEUtils.SpawnExplotionFriendly(Projectile.GetSource_FromThis(), Projectile.GetOwner(), target.Center, Projectile.damage, scale * 54 * (Radius / 180f), Projectile.DamageType);
+                CEUtils.SpawnExplotionFriendly(Projectile.GetSource_FromThis(), Projectile.GetOwner(), target.Center, Projectile.damage / 5, scale * 54 * (Radius / 180f), Projectile.DamageType);
             }
         }
     }

--- a/Content/Items/Weapons/Swirlblades/BlazingSwirlblade.cs
+++ b/Content/Items/Weapons/Swirlblades/BlazingSwirlblade.cs
@@ -64,6 +64,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
         {
             CreateRecipe()
                 .AddIngredient(ModContent.ItemType<RunicSwirlblade>())
+                .AddIngredient(ModContent.ItemType<MoltenAmputator>())
                 .AddIngredient<DivineGeode>(12)
                 .AddIngredient<UnholyEssence>(8)
                 .AddTile(TileID.MythrilAnvil)

--- a/Content/Items/Weapons/Swirlblades/BrillianceSwirlblade.cs
+++ b/Content/Items/Weapons/Swirlblades/BrillianceSwirlblade.cs
@@ -24,8 +24,8 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
             Item.useAnimation = Item.useTime = 24;
             Item.width = 42;
             Item.height = 46;
-            Item.damage = 27;
-            Item.ArmorPenetration = 10;
+            Item.damage = 7;
+            Item.ArmorPenetration = 7;
             Item.UseSound = SoundID.Item1 with { Volume = 1.2f };
             Item.value = CalamityGlobalItem.RarityGreenBuyPrice;
             Item.rare = ItemRarityID.Green;
@@ -38,7 +38,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
             Item.noMelee = true;
             Item.noUseGraphic = true;
         }
-        public override float StealthDamageMultiplier => 1.8f;
+        public override float StealthDamageMultiplier => 1.0f;
         public override float StealthVelocityMultiplier => 1.25f;
 
         public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)

--- a/Content/Items/Weapons/Swirlblades/FlamingSwirlblade.cs
+++ b/Content/Items/Weapons/Swirlblades/FlamingSwirlblade.cs
@@ -28,7 +28,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
             Item.useAnimation = Item.useTime = 24;
             Item.width = 48;
             Item.height = 52;
-            Item.damage = 7;
+            Item.damage = 8;
             Item.ArmorPenetration = 8;
             Item.UseSound = SoundID.Item1 with { Volume = 1.2f };
             Item.value = CalamityGlobalItem.RarityLightRedBuyPrice;
@@ -42,7 +42,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
             Item.noMelee = true;
             Item.noUseGraphic = true;
         }
-        public override float StealthDamageMultiplier => 1.0f;
+        public override float StealthDamageMultiplier => 0.8f;
         public override float StealthVelocityMultiplier => 1.4f;
 
         public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
@@ -58,7 +58,8 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
         public override void AddRecipes()
         {
             CreateRecipe()
-                .AddIngredient(ItemID.HellstoneBar, 25)
+                .AddIngredient(ModContent.ItemType<BrillianceSwirlblade>())
+                .AddIngredient(ItemID.HellstoneBar, 8)
                 .AddTile(TileID.Anvils)
                 .Register();
         }

--- a/Content/Items/Weapons/Swirlblades/FlamingSwirlblade.cs
+++ b/Content/Items/Weapons/Swirlblades/FlamingSwirlblade.cs
@@ -28,8 +28,8 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
             Item.useAnimation = Item.useTime = 24;
             Item.width = 48;
             Item.height = 52;
-            Item.damage = 56;
-            Item.ArmorPenetration = 15;
+            Item.damage = 7;
+            Item.ArmorPenetration = 8;
             Item.UseSound = SoundID.Item1 with { Volume = 1.2f };
             Item.value = CalamityGlobalItem.RarityLightRedBuyPrice;
             Item.rare = ItemRarityID.LightRed;
@@ -42,7 +42,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
             Item.noMelee = true;
             Item.noUseGraphic = true;
         }
-        public override float StealthDamageMultiplier => 1.8f;
+        public override float StealthDamageMultiplier => 1.0f;
         public override float StealthVelocityMultiplier => 1.4f;
 
         public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
@@ -58,8 +58,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
         public override void AddRecipes()
         {
             CreateRecipe()
-                .AddIngredient(ModContent.ItemType<BrillianceSwirlblade>())
-                .AddIngredient(ItemID.HellstoneBar, 8)
+                .AddIngredient(ItemID.HellstoneBar, 25)
                 .AddTile(TileID.Anvils)
                 .Register();
         }
@@ -164,7 +163,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
 
         public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
         {
-            target.AddBuff(BuffID.OnFire3, 300);
+            target.AddBuff(BuffID.OnFire3, 90);
             if(!target.boss)
             {
                 target.velocity *= 0.6f;
@@ -219,7 +218,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
         }
         public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
         {
-            target.AddBuff(BuffID.OnFire3, 300);
+            target.AddBuff(BuffID.OnFire3, 90);
 
             float scale = 1.5f;
             for (int i = 0; i < 12; i++)

--- a/Content/Items/Weapons/Swirlblades/GlacierSwirlblade.cs
+++ b/Content/Items/Weapons/Swirlblades/GlacierSwirlblade.cs
@@ -28,7 +28,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
             Item.useAnimation = Item.useTime = 28;
             Item.width = 92;
             Item.height = 92;
-            Item.damage = 32;
+            Item.damage = 35;
             Item.ArmorPenetration = 10;
             Item.UseSound = SoundID.Item1 with { Volume = 1.2f };
             Item.value = CalamityGlobalItem.RarityPinkBuyPrice;
@@ -58,7 +58,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
         public override void AddRecipes()
         {
             CreateRecipe()
-                .AddIngredient(ModContent.ItemType<BrillianceSwirlblade>())
+                .AddIngredient(ModContent.ItemType<AzafureSwirlblade>())
                 .AddIngredient(ModContent.ItemType<IceStar>())
                 .AddIngredient(ModContent.ItemType<CryonicBar>(), 6)
                 .AddTile(TileID.MythrilAnvil)
@@ -185,7 +185,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
             Projectile.height = 28;
             Projectile.tileCollide = false;
             Projectile.timeLeft = 120;
-            Projectile.localNPCHitCooldown = 15;
+            Projectile.localNPCHitCooldown = 18;
             Projectile.light = 0.7f;
         }
         public override bool ShouldUpdatePosition()

--- a/Content/Items/Weapons/Swirlblades/GlacierSwirlblade.cs
+++ b/Content/Items/Weapons/Swirlblades/GlacierSwirlblade.cs
@@ -28,7 +28,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
             Item.useAnimation = Item.useTime = 28;
             Item.width = 92;
             Item.height = 92;
-            Item.damage = 220;
+            Item.damage = 32;
             Item.ArmorPenetration = 10;
             Item.UseSound = SoundID.Item1 with { Volume = 1.2f };
             Item.value = CalamityGlobalItem.RarityPinkBuyPrice;
@@ -42,7 +42,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
             Item.noMelee = true;
             Item.noUseGraphic = true;
         }
-        public override float StealthDamageMultiplier => 0.6f;
+        public override float StealthDamageMultiplier => 0.5f;
         public override float StealthVelocityMultiplier => 1.2f;
 
         public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
@@ -58,7 +58,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
         public override void AddRecipes()
         {
             CreateRecipe()
-                .AddIngredient(ModContent.ItemType<AzafureSwirlblade>())
+                .AddIngredient(ModContent.ItemType<BrillianceSwirlblade>())
                 .AddIngredient(ModContent.ItemType<IceStar>())
                 .AddIngredient(ModContent.ItemType<CryonicBar>(), 6)
                 .AddTile(TileID.MythrilAnvil)
@@ -159,7 +159,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
             {
                 for (int i = 0; i < (Projectile.Calamity().stealthStrike ? 4 : 2); i++)
                 {
-                    Projectile.NewProjectile(Projectile.GetSource_FromThis(), Projectile.Center, CEUtils.randomRot().ToRotationVector2() * Main.rand.NextFloat(32, 38) * (Projectile.Calamity().stealthStrike ? 1.5f : 1), sawType, Projectile.damage / 3, 6, Projectile.owner, Radius * (Projectile.Calamity().stealthStrike ? 0.5f : 0.4f));
+                    Projectile.NewProjectile(Projectile.GetSource_FromThis(), Projectile.Center, CEUtils.randomRot().ToRotationVector2() * Main.rand.NextFloat(32, 38) * (Projectile.Calamity().stealthStrike ? 1.5f : 1), sawType, Projectile.damage / 5, 6, Projectile.owner, Radius * (Projectile.Calamity().stealthStrike ? 0.5f : 0.4f));
                 }
             }
         }
@@ -185,7 +185,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
             Projectile.height = 28;
             Projectile.tileCollide = false;
             Projectile.timeLeft = 120;
-            Projectile.localNPCHitCooldown = 6;
+            Projectile.localNPCHitCooldown = 15;
             Projectile.light = 0.7f;
         }
         public override bool ShouldUpdatePosition()

--- a/Content/Items/Weapons/Swirlblades/RunicSwirlblade.cs
+++ b/Content/Items/Weapons/Swirlblades/RunicSwirlblade.cs
@@ -29,7 +29,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
             Item.useAnimation = Item.useTime = 30;
             Item.width = 50;
             Item.height = 58;
-            Item.damage = 380;
+            Item.damage = 50;
             Item.ArmorPenetration = 12;
             Item.UseSound = SoundID.Item1 with { Volume = 1f };
             Item.value = CalamityGlobalItem.RarityYellowBuyPrice;
@@ -43,7 +43,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
             Item.noMelee = true;
             Item.noUseGraphic = true;
         }
-        public override float StealthDamageMultiplier => 1.4f;
+        public override float StealthDamageMultiplier => 0.6f;
         public override float StealthVelocityMultiplier => 1.2f;
 
         public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
@@ -60,8 +60,8 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
         {
             CreateRecipe()
                 .AddIngredient(ModContent.ItemType<GlacierSwirlblade>())
-                .AddIngredient(ModContent.ItemType<SamsaraSlicer>())
-                .AddIngredient(ItemID.Ectoplasm, 6)
+                .AddIngredient(ModContent.ItemType<AzafureSwirlblade>())
+                .AddIngredient(ItemID.SpectreBar, 20)
                 .AddTile(TileID.MythrilAnvil)
                 .Register();
         }

--- a/Content/Items/Weapons/Swirlblades/RunicSwirlblade.cs
+++ b/Content/Items/Weapons/Swirlblades/RunicSwirlblade.cs
@@ -30,7 +30,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
             Item.width = 50;
             Item.height = 58;
             Item.damage = 50;
-            Item.ArmorPenetration = 12;
+            Item.ArmorPenetration = 15;
             Item.UseSound = SoundID.Item1 with { Volume = 1f };
             Item.value = CalamityGlobalItem.RarityYellowBuyPrice;
             Item.rare = ItemRarityID.Yellow;
@@ -60,8 +60,8 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
         {
             CreateRecipe()
                 .AddIngredient(ModContent.ItemType<GlacierSwirlblade>())
-                .AddIngredient(ModContent.ItemType<AzafureSwirlblade>())
-                .AddIngredient(ItemID.SpectreBar, 20)
+                .AddIngredient(ModContent.ItemType<SamsaraSlicer>())
+                .AddIngredient(ItemID.Ectoplasm, 6)
                 .AddTile(TileID.MythrilAnvil)
                 .Register();
         }

--- a/Content/Items/Weapons/Swirlblades/SawofMacrocosm.cs
+++ b/Content/Items/Weapons/Swirlblades/SawofMacrocosm.cs
@@ -67,7 +67,8 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
         {
             CreateRecipe()
                 .AddIngredient(ModContent.ItemType<BlazingSwirlblade>())
-                .AddIngredient(ModContent.ItemType<CosmiliteBar>(), 8)
+                .AddIngredient(ModContent.ItemType<DimensionTearingDisk>())
+                .AddIngredient(ModContent.ItemType<CosmiliteBar>(), 6)
                 .AddIngredient(ModContent.ItemType<AscendantSpiritEssence>(), 2)
                 .AddTile<CosmicAnvil>()
                 .Register();

--- a/Content/Items/Weapons/Swirlblades/SawofMacrocosm.cs
+++ b/Content/Items/Weapons/Swirlblades/SawofMacrocosm.cs
@@ -35,7 +35,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
             Item.useAnimation = Item.useTime = 40;
             Item.width = 86;
             Item.height = 86;
-            Item.damage = 230;
+            Item.damage = 225;
             Item.ArmorPenetration = 30;
             Item.UseSound = SoundID.Item1 with { Volume = 1.2f };
             Item.value = CalamityGlobalItem.RarityDarkBlueBuyPrice;
@@ -49,7 +49,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
             Item.noMelee = true;
             Item.noUseGraphic = true;
         }
-        public override float StealthDamageMultiplier => 0.66f;
+        public override float StealthDamageMultiplier => 0.6f;
         public override float StealthVelocityMultiplier => 1.25f;
 
         public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)

--- a/Content/Items/Weapons/Swirlblades/SawofMacrocosm.cs
+++ b/Content/Items/Weapons/Swirlblades/SawofMacrocosm.cs
@@ -35,8 +35,8 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
             Item.useAnimation = Item.useTime = 40;
             Item.width = 86;
             Item.height = 86;
-            Item.damage = 900;
-            Item.ArmorPenetration = 10;
+            Item.damage = 230;
+            Item.ArmorPenetration = 30;
             Item.UseSound = SoundID.Item1 with { Volume = 1.2f };
             Item.value = CalamityGlobalItem.RarityDarkBlueBuyPrice;
             Item.rare = ModContent.RarityType<CosmicPurple>();
@@ -49,7 +49,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
             Item.noMelee = true;
             Item.noUseGraphic = true;
         }
-        public override float StealthDamageMultiplier => 1.8f;
+        public override float StealthDamageMultiplier => 0.66f;
         public override float StealthVelocityMultiplier => 1.25f;
 
         public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
@@ -67,8 +67,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
         {
             CreateRecipe()
                 .AddIngredient(ModContent.ItemType<BlazingSwirlblade>())
-                .AddIngredient(ModContent.ItemType<DimensionTearingDisk>())
-                .AddIngredient(ModContent.ItemType<CosmiliteBar>(), 6)
+                .AddIngredient(ModContent.ItemType<CosmiliteBar>(), 8)
                 .AddIngredient(ModContent.ItemType<AscendantSpiritEssence>(), 2)
                 .AddTile<CosmicAnvil>()
                 .Register();
@@ -256,7 +255,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
         public override void SetDefaults()
         {
             base.SetDefaults();
-            Projectile.localNPCHitCooldown = 6;
+            Projectile.localNPCHitCooldown = 15;
             Projectile.tileCollide = false;
         }
         public override bool CollideWithNPC => false;
@@ -271,7 +270,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Swirlblades
             {
                 if (Main.myPlayer == Projectile.owner)
                 {
-                    Projectile.NewProjectile(Projectile.GetSource_FromThis(), Projectile.Center, Vector2.Zero, ModContent.ProjectileType<MacrocosmVoidBolt>(), Projectile.damage, 4f, Projectile.owner, Projectile.ai[1], orgPos.X, orgPos.Y);
+                    Projectile.NewProjectile(Projectile.GetSource_FromThis(), Projectile.Center, Vector2.Zero, ModContent.ProjectileType<MacrocosmVoidBolt>(), (int)(Projectile.damage * 0.66f), 4f, Projectile.owner, Projectile.ai[1], orgPos.X, orgPos.Y);
                 }
             }
             if(TimeUtilSpread > 10)

--- a/Content/Items/Weapons/Whips/Crystedge.cs
+++ b/Content/Items/Weapons/Whips/Crystedge.cs
@@ -14,7 +14,7 @@ namespace CalamityEntropy.Content.Items.Weapons.Whips
 
         public override void SetDefaults()
         {
-            Item.DefaultToWhip(ModContent.ProjectileType<CrystedgeWhipSpawner>(), 60, 3, 5, 72);
+            Item.DefaultToWhip(ModContent.ProjectileType<CrystedgeWhipSpawner>(), 48, 3, 5, 72);
             Item.rare = ItemRarityID.Pink;
             Item.value = CalamityGlobalItem.RarityPinkBuyPrice;
             Item.autoReuse = true;

--- a/Content/Items/Weapons/Whips/TectonicChainBlade.cs
+++ b/Content/Items/Weapons/Whips/TectonicChainBlade.cs
@@ -20,12 +20,12 @@ namespace CalamityEntropy.Content.Items.Weapons.Whips
 {
     public class TectonicChainBlade : BaseWhipItem
     {
-        public override int TagDamage => 7;
+        public override int TagDamage => 3;
         public int UseCount = 0;
         
         public override void SetDefaults()
         {
-            Item.DefaultToWhip(ModContent.ProjectileType<TectonicChainBladeWhip>(), 33, 3, 4, 28);
+            Item.DefaultToWhip(ModContent.ProjectileType<TectonicChainBladeWhip>(), 22, 3, 4, 28);
             Item.rare = ItemRarityID.LightRed;
             Item.value = CalamityGlobalItem.RarityLightRedBuyPrice;
             Item.autoReuse = true;


### PR DESCRIPTION
1.棱镜飞刃，面板调整为7，穿甲调整为7，潜伏倍率100%（强于南瓜炸弹和海沫炸弹，略弱于猫猫雷管，偏全能）
2.烈火旋刃，面板调整为8，穿甲为8，潜伏倍率80%，造成的狱炎减益时间降低为1.5秒（普攻对单略弱于陨星拳套，潜伏略强于陨星全套，可以在t2邪恶战中优势互补）
3.阿萨辐勒旋刃，面板调整为32，穿甲为10，潜伏倍率75%（适合对群，对单约等于幻光石板）
4.寒冰旋刃，面板调整为35，穿甲提升至15，潜伏倍率50%，小刀片的倍率降低20%，造成无敌帧提升为18（打灾影略微弱于烈火之心普攻，强于其他神圣武器）
5.灵魂旋刃，面板调整为50，,穿甲提升至15，潜伏倍率60%（略弱于符文飞刀，和回春环刃优势互补，适合打石巨人、两月和阿娜西塔）
6.亵渎旋刃，面板调整为200，穿甲为25，潜伏倍率35%，亵渎cjb倍率调整为66%，爆炸倍率调整为20%（普攻伤害介于裂阳和切碎者之间，适合对战风吞，虚空和神吞，直接打体节）
7.弑神旋刃，面板调整为225，穿甲30，潜伏倍率60%，激光倍率调整为66%，小刀片无敌帧提升至15（对龙强于剧毒旋风，神后的原灾盗贼武器实在不适合打龙）
8.板块链刃，面板降低至22，标记伤害降低为3，板块倍率降低为33%，略强于脊柱骨鞭
9.幻光石板，潜伏倍率降低至90%，使其潜伏伤害大致和硫火飞爪接近
10.凝胶晶鞭，面板降低至48，使其略弱于迪朗达尔
11.幻光星瓶，面板降低至30，使其实战强度大概和一王后的沉眠巡焰者差不多
12.妖龙mk2，面板降低至12500，献奉炼铸后1.5倍无限大地水平
13.重平衡静岳之剑，使其全流程强度大概处于一个同时期中偏上的保底位置。